### PR TITLE
minor bug fix node.py

### DIFF
--- a/node.py
+++ b/node.py
@@ -1436,7 +1436,7 @@ class p2pProtocol(Protocol):
 
 		e = self.buffer.find(chr(0)+chr(0)+chr(255))
 
-		if e == -1 and len(self.buffer) >= 8+m+3:			#we already have more than the message length with no terminator, cant trust data
+		if e == -1 and len(self.buffer) > 8+m+3:			#we already have more than the message length with no terminator, cant trust data
 			print 'Data received in buffer invalid and deleted.'
 			self.buffer = ''
 			return False


### PR DESCRIPTION
The condition in line 1439 was 

if e == -1 and len(self.buffer) >= 8+m+3:

but it should be > 8+m+3  as our data format is following
 chr(255)+chr(0)+chr(0)+struct.pack('>L', len(data))+chr(0)+data+chr(0)+chr(0)+chr(255)
1+1+1+4+1+m+1+1+1
8+m+3
So a size greater than 8+m+3 makes it invalid.

