### PR TITLE
Bug Fix node.py

### DIFF
--- a/node.py
+++ b/node.py
@@ -1440,12 +1440,13 @@ class p2pProtocol(Protocol):
 
 		if d != -1 and d < e:						#found start position must be less than end position
 			m = struct.unpack('>L', self.buffer[d+3:d+7])[0]	#get length of message
+			self.buffer = self.buffer[d:]				#move buffer to initiator
 		else:
-			self.clean_buffer('Data received buffer full of garbage and deleted.', e)
+			self.clean_buffer('Data received buffer full of garbage and deleted.', e+3)
 			return False
 
 		if len(self.buffer) < 8+m+3:			#we already have more than the message length with no terminator, cant trust data
-			self.clean_buffer('Data received in buffer invalid and deleted.', e)
+			self.clean_buffer('Data received in buffer invalid and deleted.', e+3)
 			return False
 
 		self.messages.append(self.buffer[8:8+m])

--- a/node.py
+++ b/node.py
@@ -1426,7 +1426,7 @@ class p2pProtocol(Protocol):
 		if upto==-1:
 			self.buffer = ''					#Clean buffer completely
 		else:
-			self.buffer = self.buffer[upto+1:] 			#Clean buffer till the value provided in upto
+			self.buffer = self.buffer[upto:] 			#Clean buffer till the value provided in upto
 
 	def parse_buffer(self):
 		if len(self.buffer)==0:

--- a/node.py
+++ b/node.py
@@ -1437,7 +1437,6 @@ class p2pProtocol(Protocol):
 
 		if d != -1 and d < e:						#found start position must be less than end position
 			m = struct.unpack('>L', self.buffer[d+3:d+7])[0]	#get length of message
-			self.buffer = self.buffer[d:]					#delete up to the start of message
 		else:
 			self.clean_buffer('Data received buffer full of garbage and deleted.')
 			return False

--- a/node.py
+++ b/node.py
@@ -1436,7 +1436,7 @@ class p2pProtocol(Protocol):
 
 		e = self.buffer.find(chr(0)+chr(0)+chr(255))
 
-		if e == -1 and len(self.buffer) >= 8+m+3:			#we already have more than the message length with no terminator, cant trust data
+		if e == -1 and len(self.buffer) > 8+m+3:			#we already have more than the message length with no terminator, cant trust data
 			print 'Data received in buffer invalid and deleted.'
 			self.buffer = ''
 			return False

--- a/node.py
+++ b/node.py
@@ -1420,13 +1420,13 @@ class p2pProtocol(Protocol):
 
 		#struct.pack('>L', len(data))
 
-	def clean_buffer(self, reason='', upto=-1):
+	def clean_buffer(self, reason=None, upto=None):
 		if reason:
 			print reason
-		if upto==-1:
-			self.buffer = ''					#Clean buffer completely
-		else:
+		if upto:
 			self.buffer = self.buffer[upto:] 			#Clean buffer till the value provided in upto
+		else:
+			self.buffer = ''					#Clean buffer completely
 
 	def parse_buffer(self):
 		if len(self.buffer)==0:

--- a/node.py
+++ b/node.py
@@ -1436,6 +1436,8 @@ class p2pProtocol(Protocol):
 		e = self.buffer.find(chr(0)+chr(0)+chr(255))
 
 		if e==-1:							#End not found, pass for next iteration
+			if d==-1:
+				self.clean_buffer('Message without initiator and terminator')
 			return False
 
 		if d != -1 and d < e:						#found start position must be less than end position

--- a/node.py
+++ b/node.py
@@ -1420,28 +1420,30 @@ class p2pProtocol(Protocol):
 
 		#struct.pack('>L', len(data))
 
+	def clean_buffer(self, reason=""):
+		if reason:
+			print reason
+		self.buffer = ''
+
 	def parse_buffer(self):
 		if len(self.buffer)==0:
 			return False
 
 		d = self.buffer.find(chr(255)+chr(0)+chr(0))
+		e = self.buffer.find(chr(0)+chr(0)+chr(255))
 
-		if d != -1:
+		if e==-1:							#End not found, pass for next iteration
+			return False
+
+		if d != -1 and d < e:						#found start position must be less than end position
 			m = struct.unpack('>L', self.buffer[d+3:d+7])[0]	#get length of message
 			self.buffer = self.buffer[d:]					#delete up to the start of message
 		else:
-			print 'Data received buffer full of garbage and deleted.'
-			self.buffer = ''
+			self.clean_buffer('Data received buffer full of garbage and deleted.')
 			return False
 
-		e = self.buffer.find(chr(0)+chr(0)+chr(255))
-
-		if e == -1 and len(self.buffer) > 8+m+3:			#we already have more than the message length with no terminator, cant trust data
-			print 'Data received in buffer invalid and deleted.'
-			self.buffer = ''
-			return False
-
-		if e == -1:											#no end to message in the buffer yet..
+		if len(self.buffer) > 8+m+3:			#we already have more than the message length with no terminator, cant trust data
+			self.clean_buffer('Data received in buffer invalid and deleted.')
 			return False
 
 		self.messages.append(self.buffer[8:8+m])

--- a/node.py
+++ b/node.py
@@ -1420,10 +1420,13 @@ class p2pProtocol(Protocol):
 
 		#struct.pack('>L', len(data))
 
-	def clean_buffer(self, reason=""):
+	def clean_buffer(self, reason='', upto=-1):
 		if reason:
 			print reason
-		self.buffer = ''
+		if upto==-1:
+			self.buffer = ''					#Clean buffer completely
+		else:
+			self.buffer = self.buffer[upto+1:] 			#Clean buffer till the value provided in upto
 
 	def parse_buffer(self):
 		if len(self.buffer)==0:
@@ -1438,11 +1441,11 @@ class p2pProtocol(Protocol):
 		if d != -1 and d < e:						#found start position must be less than end position
 			m = struct.unpack('>L', self.buffer[d+3:d+7])[0]	#get length of message
 		else:
-			self.clean_buffer('Data received buffer full of garbage and deleted.')
+			self.clean_buffer('Data received buffer full of garbage and deleted.', e)
 			return False
 
-		if len(self.buffer) > 8+m+3:			#we already have more than the message length with no terminator, cant trust data
-			self.clean_buffer('Data received in buffer invalid and deleted.')
+		if len(self.buffer) < 8+m+3:			#we already have more than the message length with no terminator, cant trust data
+			self.clean_buffer('Data received in buffer invalid and deleted.', e)
 			return False
 
 		self.messages.append(self.buffer[8:8+m])


### PR DESCRIPTION
clean_buffer
a new function has been added, that cleans the buffer, reason for cleaning and position till where cleaning has to be done can be provided to this function.

if d != -1:
The bug has been fixed, as if the start point has been found, it just moves the buffer d points ahead, later if end point is not found, the buffer gets changed, so on next pass, the start point will not be found, which will result into bug.

New Case added
in case message has some length but no initiator or terminator found, just clean the buffer.