### PR TITLE
Minor Bug Fix node.py

### DIFF
--- a/node.py
+++ b/node.py
@@ -1750,7 +1750,7 @@ class p2pFactory(ServerFactory):
 	def send_stake_block(self, block_obj):
 		printL(( '<<<Transmitting POS created block', str(block_obj.blockheader.blocknumber), block_obj.blockheader.headerhash))
 		for peer in self.peers:
-			peer.transport.write(self.f_wrap_message('S4'+chain.json_byestream(block_obj)))
+			peer.transport.write(self.f_wrap_message('S4'+chain.json_bytestream(block_obj)))
 		return
 
 	# send/relay block to peers


### PR DESCRIPTION
Minor bug as send_stake_block function in node.py was calling to json_byestream

Line 1753 changed from 
peer.transport.write(self.f_wrap_message('S4'+chain.json_byestream(block_obj)))

to

peer.transport.write(self.f_wrap_message('S4'+chain.json_bytestream(block_obj)))