### PR TITLE
latency function fix node.py

### DIFF
--- a/node.py
+++ b/node.py
@@ -827,7 +827,7 @@ class ApiProtocol(Protocol):
 
 	def latency(self, type=None):
 		output = {}
-		if type.lower() in ['mean', 'median', 'last']:
+		if type and type.lower() in ['mean', 'median', 'last']:
 			for block_num in chain.stake_validator_latency.keys():
 				output[block_num] = {}
 				for stake in chain.stake_validator_latency[block_num].keys():


### PR DESCRIPTION
latency function was trying to convert value to type in lower, without checking if the type content is None or it has some string value. This was causing a minor bug. This minor bug has been fixed.