### PR TITLE
Bug Fix for Synchronization

### DIFF
--- a/chain.py
+++ b/chain.py
@@ -36,6 +36,9 @@ stake_reveal = []
 stake_reveal_one = []
 stake_reveal_two = []
 stake_reveal_three = []
+last_stake_reveal_one = []
+last_stake_reveal_two = []
+last_stake_reveal_three = []
 stake_ban_list = []
 stake_ban_block = {}
 stake_pool = []
@@ -1924,6 +1927,5 @@ def create_my_tx(txfrom, txto, n, fee=0):
 		return (tx, msg)
 	else:
 		return (False, msg)
-
 
 


### PR DESCRIPTION
When chain.stake_reveal_one, chain.stake_reveal_two, chain.stake_reveal_three contains multiple reveal messages by the same stakers. It results into selection of invalid blocknumber for the Synchronization.

Files modified
- node.py
- chain.py