### PR TITLE
Added Transaction Rejection Pool

### DIFF
--- a/chain.py
+++ b/chain.py
@@ -52,6 +52,7 @@ pos_consensus = []
 pos_flag = []
 ip_list = []
 blockheight_map = []
+rejection_txpool = [None]*100
 stake_validator_latency = defaultdict(dict)
 
 printL(( 'QRL blockchain ledger v 0.04a'))


### PR DESCRIPTION
A new list rejection_txpool has been added into chain.py. The maximum size of list is 100 and it maintains the headerhash of last 100 transactions which has been rejected. So that if the same transaction transmitted again, it can be rejected without validation.