### PR TITLE
Bug fix: Forked block received, stall the POS cycle of normal chain

### DIFF
--- a/chain.py
+++ b/chain.py
@@ -543,6 +543,8 @@ class CreateBlock():
 			for st in stake_pool:
 				if st.epoch != curr_epoch:
 					printL (( 'Skipping st as epoch mismatch, CreateBlock()' ))
+					printL (( 'Expected st epoch : ', curr_epoch ))
+					printL (( 'Found st epoch : ', st.epoch )) 
 					continue
 				sthashes.append(st.hash)
 			hashedstake = sha256(''.join(sthashes))
@@ -550,6 +552,9 @@ class CreateBlock():
 		for st in stake_pool:
 			if st.epoch != curr_epoch:
 				printL (( 'Skipping st as epoch mismatch, CreateBlock()' ))
+				printL (( 'Expected st epoch : ', curr_epoch ))
+				printL (( 'Found st epoch : ', st.epoch )) 
+
 				continue
 			self.stake.append(st)
 

--- a/node.py
+++ b/node.py
@@ -664,8 +664,15 @@ def received_block_logic(block_obj):
 			return
 	
 	if block_obj.blockheader.prev_blockheaderhash != chain.m_blockchain[-1].blockheader.headerhash:
+			# Fork recovery should not be called from here. As it could be a fake block 
+			# or block from some other POS cycle.
+			# in case if the block is from the current cycle, it will be switch to unsynced
+			# after some delay
 			printL(( '>>>WARNING: FORK..'))
-			fork.fork_recovery(block_obj.blockheader.blocknumber-1, chain, randomize_headerhash_fetch)
+			printL(( 'Block rejected hash doesnt matches with prev_blockheaderhash' ))
+			printL(( 'Expected prev_headerhash - ', chain.m_blockchain[-1].blockheader.headerhash ))
+			printL(( 'Found prev_headerhash - ', block_obj.blockheader.prev_blockheaderhash ))
+			#fork.fork_recovery(block_obj.blockheader.blocknumber-1, chain, randomize_headerhash_fetch)
 			return
 
 	# pos checks


### PR DESCRIPTION
Forked block received, stall the POS cycle of normal chain. Thus fork recovery will not be called in case of block received in pre_block_logic, rather block will only be rejected.