### PR TITLE
Prevent user from loosing Quanta on their last wallet signature

### DIFF
--- a/wallet.py
+++ b/wallet.py
@@ -181,6 +181,19 @@ class Wallet:
 
         return list_addr
 
+    def get_num_signatures(self, address_to_check):
+        if not self.chain.my:
+            addr = self.f_read_wallet()
+        else:
+            addr = self.chain.my
+
+        for address in addr:
+            if address[0] == address_to_check:
+                if type(address[1]) == list:
+                    return address[1][0].signatures - self.state.state_nonce(address[0])
+                else:  # xmss
+                    return address[1].remaining
+
     def getnewaddress(self, signatures=4096, type='XMSS',
                       SEED=None):  # new address format is a list of two items [address, data structure from random_mss call]
         addr = []

--- a/walletprotocol.py
+++ b/walletprotocol.py
@@ -369,6 +369,15 @@ class WalletProtocol(Protocol):
                 '>>> Invalid amount to send. Type a number less than or equal to the balance of the sending address' + '\r\n')
             return
 
+        # Stop user from sending less than their entire balance if they've only
+        # got one signature remaining.
+        sigsremaining = self.factory.chain.wallet.get_num_signatures(self.factory.chain.my[int(args[0])][0])
+        if sigsremaining is 1:
+            if amount < balance:
+                self.transport.write(
+                    '>>> Stop! You only have one signing signature remaining. You should send your entire balance or the remainder will be lost!' + '\r\n')
+                return
+
         tx = self.factory.chain.create_my_tx(txfrom=int(args[0]), txto=args[1], amount=amount)
 
         if tx is False:


### PR DESCRIPTION
This PR prevents the user from sending less than their account balance when they've only got a single signature left.