### PR TITLE
Prune start of create_tree

### DIFF
--- a/merkle.py
+++ b/merkle.py
@@ -1188,24 +1188,10 @@ class Merkle():
 
     def create_tree(self):
 
-        if self.num_leaves <= 2:
+        if self.num_leaves <= 2: # catch case for which log doesn't do the job
             num_branches = 1
-        elif self.num_leaves > 2 and self.num_leaves <= 4:
-            num_branches = 2
-        elif self.num_leaves > 4 and self.num_leaves <= 8:
-            num_branches = 3
-        elif self.num_leaves > 8 and self.num_leaves <= 16:
-            num_branches = 4
-        elif self.num_leaves > 16 and self.num_leaves <= 32:
-            num_branches = 5
-        elif self.num_leaves > 32 and self.num_leaves <= 64:
-            num_branches = 6
-        elif self.num_leaves > 64 and self.num_leaves <= 128:
-            num_branches = 7
-        elif self.num_leaves > 128 and self.num_leaves <= 256:
-            num_branches = 8
-        elif self.num_leaves > 256 and self.num_leaves <= 512:
-            num_branches = 9
+        elif self.num_leaves <= 512:
+            num_branches = int(ceil(log(num_leaves, 2)))
 
         self.num_branches = num_branches
         self.tree.append(self.base)


### PR DESCRIPTION
Make a computation in create_tree() much shorter.

The following test program proves that the new piece of source code produces the exact same result for every input as the old source code:
```python
import math

def old(num_leaves):
	num_branches = None
	if num_leaves <= 2:
		num_branches = 1
	elif num_leaves > 2 and num_leaves <= 4:
		num_branches = 2
	elif num_leaves > 4 and num_leaves <= 8:
		num_branches = 3
	elif num_leaves > 8 and num_leaves <= 16:
		num_branches = 4
	elif num_leaves > 16 and num_leaves <= 32:
		num_branches = 5
	elif num_leaves > 32 and num_leaves <= 64:
		num_branches = 6
	elif num_leaves > 64 and num_leaves <= 128:
		num_branches = 7
	elif num_leaves > 128 and num_leaves <= 256:
		num_branches = 8
	elif num_leaves > 256 and num_leaves <= 512:
		num_branches = 9
		# no result above 512
	return num_branches

def new(num_leaves):
	if num_leaves < 2: # catch case for which logarithm fails
		return 1
	if num_leaves > 512: # don't do anything above 512
		return None
	num_branches = int(math.ceil(math.log(num_leaves, 2)))
	return num_branches

start, end = 0, 512
for i in range(start-10, end+10): # test beyond boundaries for equal output
	o,n = old(i), new(i)
	print i,o,n
	assert o == n
```

One could also remove the `elif self.num_leaves <= 512:` in the merkle.py als just put `else:` there, this way it would work with trees of arbitrary sizes.
