### PR TITLE
Create autostartQRL.sh

### DIFF
--- a/autostartQRL.sh
+++ b/autostartQRL.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+echo "Killing python..."
+/usr/bin/pkill python
+
+echo "Updating QRL..."
+cd $HOME/QRL
+git pull
+
+echo "Updating QRL pyhton dependencies..."
+sudo pip install -r requirements.txt
+
+echo "Restart QRL node"
+python main.py
+
+$SHELL


### PR DESCRIPTION
I suggest to include autostartQRL.sh script into /QRL repository in order to avoid users to add it manually.
Also, I have updated the documentation to add it into crontab during testnet to have automatique update + reboot during testnet
What do you think about ?