### PR TITLE
Allowing user custom configuration

### DIFF
--- a/qrl/core/config.py
+++ b/qrl/core/config.py
@@ -4,6 +4,8 @@ from os.path import expanduser
 
 import os
 
+import yaml
+
 
 class UserConfig(object):
     __instance = None
@@ -29,6 +31,9 @@ class UserConfig(object):
         self.max_peers_limit = 40  # Number of allowed peers
         self.data_path = expanduser("~/.qrl/data")
         self.wallet_path = expanduser("~/.qrl/wallet")
+        self.config_path = '~/.qrl/config.yaml'
+
+        self.load_yaml(expanduser(self.config_path))
 
     @staticmethod
     def getInstance():
@@ -36,13 +41,16 @@ class UserConfig(object):
             return UserConfig()
         return UserConfig.__instance
 
-    def from_yaml(self, path):
+    def load_yaml(self, file_path):
         """
         Overrides default configuration using a yaml file
         :param path: The path to the configuration file
         """
-        # TODO: Complete this part
-        pass
+        if os.path.isfile(file_path):
+            with open(file_path) as f:
+                dataMap = yaml.safe_load(f)
+                if dataMap is not None:
+                    self.__dict__.update(**dataMap)
 
 
 def create_path(path):

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ recommonmark>=0.4.0
 sphinx==1.5.6
 sphinx_rtd_theme>=0.2.4
 enum34==1.1.6
+PyYAML==3.12


### PR DESCRIPTION
Users can define custom in a yaml file. This will allow for user configuration to be independent of python