### PR TITLE
Fix leveldb key value & blocknumber added to txhash

### DIFF
--- a/qrl/core/apiprotocol.py
+++ b/qrl/core/apiprotocol.py
@@ -454,7 +454,9 @@ class ApiProtocol(Protocol):
 
         json_tx = json.loads(txn_metadata[0])
         tx = Transaction().from_txdict(json_tx)
+        tx.blocknumber = txn_metadata[1]
         tx.timestamp = txn_metadata[2]
+
         tx_new = copy.deepcopy(tx)
         self.reformat_txn(tx_new)
         logger.info('%s found in block %s', txhash, str(txn_metadata[1]))

--- a/qrl/core/state.py
+++ b/qrl/core/state.py
@@ -222,12 +222,10 @@ class State:
     def zero_all_addresses(self):
         addresses = []
         for k, v in self.db.RangeIter('Q'):
-            if k == b'slave_info':
-                continue
             addresses.append(k)
         for address in addresses:
-            self.db.put(address, [0, 0, []])
-
+            self.db.Delete(address)
+        logger.info('Reset Finished')
         self.state_set_blockheight(0)
         return
 


### PR DESCRIPTION
zero_all_addresses now just delete all the keys instead of setting default value and invalid default value to some keys.
Fix for second issue mentioned in Issue #333 