### PR TITLE
Disconnect peers not following protocol + Txhash api fixes

### DIFF
--- a/qrl/core/apifactory.py
+++ b/qrl/core/apifactory.py
@@ -141,7 +141,10 @@ class ApiFactory(ServerFactory):
 
         json_tx = json.loads(txn_metadata[0])
         tx = Transaction().from_txdict(json_tx)
+        tx.blocknumber = txn_metadata[1]
+        tx.confirmations = self.factory.chain.height() - tx.blocknumber
         tx.timestamp = txn_metadata[2]
+
         tx_new = copy.deepcopy(tx)
         self.reformat_txn(tx_new)
         logger.info('%s found in block %s', txhash, str(txn_metadata[1]))

--- a/qrl/core/p2pprotocol.py
+++ b/qrl/core/p2pprotocol.py
@@ -963,7 +963,9 @@ class P2PProtocol(Protocol):
             tmp2 = hstr2bin(tmp.decode())
             tmp3 = bytearray(tmp2)
             m = struct.unpack('>L', tmp3)[0]  # is m length encoded correctly?
-        except ValueError as e:
+        except (UnicodeDecodeError, ValueError):
+            logger.info('Peer not following protocol %s', self.conn_identity)
+            self.transport.loseConnection()
             return False
         except Exception as e:
             logger.exception(e)


### PR DESCRIPTION
There are still some nodes running with the old testnet. And since they are not following the new messaging protocol, the node on the other side, are unable to check their proper version. Thus peers not following messaging protocol are now disconnected by default.

This is the fix for Issue #330 