### PR TITLE
Transaction validation tests now work

### DIFF
--- a/qrl/core/helper.py
+++ b/qrl/core/helper.py
@@ -11,7 +11,7 @@ from qrl.crypto.misc import sha256
 #FIXME: Lack of clear schemas could be dangerous in this case
 
 def isValidAddress(addr):
-    if addr.startswith('Q'):
+    if addr.startswith(b'Q'):
         suffix = addr[1:]
         if len(suffix) == 72:
             try:

--- a/tests/core/test_transaction.py
+++ b/tests/core/test_transaction.py
@@ -134,7 +134,7 @@ class TestSimpleTransaction(TestCase):
         self.assertEqual(100, tx.amount)
         self.assertEqual(1, tx.fee)
 
-    def disabled_test_validate_tx(self):
+    def test_validate_tx(self):
         # If we change amount, fee, txfrom, txto, (maybe include xmss stuff) txhash should change.
         tx = SimpleTransaction.create(addr_from=self.alice.get_address(),
                                       addr_to=self.bob.get_address(),
@@ -147,11 +147,11 @@ class TestSimpleTransaction(TestCase):
         tx.sign(self.alice)
 
         # We have not touched the tx: validation should pass.
-        self.assertTrue(tx.validate_tx())
+        # However, our XMSS tree height is 4, not config.dev.xmss_tree_height.
+        self.assertTrue(tx.validate_tx(height=4))
 
     def test_state_validate_tx(self):
         # Test balance not enough
-        # Test negative tx amounts
         pass
 
 
@@ -213,7 +213,7 @@ class TestStakeTransaction(TestCase):
                           '0f617ba98e6a0f426517e51aff86858da592399abcde80b1b5995a6d0b71a055'],
                          binvec2hstr(tx.hash))
 
-    def disabled_test_validate_tx(self):
+    def test_validate_tx(self):
         tx = StakeTransaction.create(blocknumber=2,
                                      xmss=self.alice,
                                      slavePK=self.bob.pk(),
@@ -226,7 +226,7 @@ class TestStakeTransaction(TestCase):
         tx.sign(self.alice)
 
         # We haven't touched the tx: validation should pass
-        self.assertTrue(tx.validate_tx())
+        self.assertTrue(tx.validate_tx(height=4))
 
     def test_get_message_hash(self):
         tx = StakeTransaction.create(blocknumber=2,


### PR DESCRIPTION
This is because tests use a XMSS tree height of 4, but normally the signatures are checked by calling XMSS.VERIFY with a height of 10, because that's what the node normally uses.
One should not need the original tree to verify a signature from that tree, so the height needs to be communicated to the tx validation function.