### PR TITLE
For Debian packaging tools to make the package depend on python3-prot…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ PyYAML==3.12
 grpcio>=1.6.3
 grpcio-tools>=1.6.3
 service_identity
+protobuf
 pyopenssl>=17.3.0
 pyqrllib>=0.2.3
 six>=1.9


### PR DESCRIPTION
…obuf, we must explicitly state that we depend on protobuf and not just let grpcio pull it in for us.

Since we also explicitly import protobuf in our code, this shouldn't be a problem.