### PR TITLE
update readme debian/ubuntu installation typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Ensure your apt sources are up to date and install dependencies
 
 ```bash
 sudo apt update
-sudo apt -y install swig3.0 python3-dev python3-pip build-essential cmake pkg-config libssl-dev libffi-dev
+sudo apt-get -y install swig3.0 python3-dev python3-pip build-essential cmake pkg-config libssl-dev libffi-dev
 ```
 
 To get the source and start the node, use the following:
@@ -86,7 +86,7 @@ start_qrl
 Install dependencies
 ```bash
 sudo apt update
-sudo apt -y install swig3.0 python3-dev build-essential cmake ninja-build libboost-random-dev libssl-dev libffi-dev
+sudo apt-get -y install swig3.0 python3-dev build-essential cmake ninja-build libboost-random-dev libssl-dev libffi-dev
 sudo pip3 install -U setuptools pip
 ```
 


### PR DESCRIPTION
two instances of installation commands did not include "apt-get" and instead contained a partial command that returns errors