### PR TITLE
txhash fixes, datatype mismatch with proto

### DIFF
--- a/qrl/core/State.py
+++ b/qrl/core/State.py
@@ -128,6 +128,9 @@ class State:
             logger.exception(e)
             txhash = []
 
+        for i in range(len(txhash)):
+            txhash[i] = txhash[i].encode()
+
         return txhash
 
     #########################################


### PR DESCRIPTION
txhash was looking for bytes type data, while leveldb stores all bytes data into string format, so on retrieving such data, we get string. Thus manually converting them into bytes to match with bytes data type.