### PR TITLE
Integrationtest mods

### DIFF
--- a/qrl/cli.py
+++ b/qrl/cli.py
@@ -13,12 +13,27 @@ def get_wallet_obj():
     walletObj = Wallet()
     return walletObj
 
+def get_address_balance(address, channel):
+    """
+    address: b'Q......'
+    channel: grpc.insecure_channel(nodeip:nodeport)
+    """
+    stub = qrl_pb2_grpc.PublicAPIStub(channel)
+    
+    getAddressStateReq = qrl_pb2.GetAddressStateReq(address=address)
+    f = stub.GetAddressState.future(getAddressStateReq, timeout=5)
+    getAddressStateResp = f.result(timeout=5)
+
+    return getAddressStateResp.state.balance
 
 # TODO add balance
 def print_wallet_list(walletObj):
-    print('Number\t\tAddress')
+    channel = get_channel()
+
+    print('Number\tAddress\tBalance')
     for pos, addr in enumerate(walletObj.address_bundle):
-        print('%s\t\t%s' % (pos, addr.address.decode()))
+        balance = get_address_balance(addr.address, channel)
+        print('%s\t%s\t%s' % (pos, addr.address.decode(), balance/1e8))  # TODO standardize quanta/shor conversion
 
 
 def select_wallet(walletObj):
@@ -44,7 +59,7 @@ def wallet():
 
 
 @wallet.command()
-def list():  # FIXME: method name is a python keyword
+def list_wallets():  # FIXME: method name is a python keyword
     """
     Lists available wallets
     """

--- a/qrl/core/Wallet.py
+++ b/qrl/core/Wallet.py
@@ -22,16 +22,17 @@ class Wallet:
     # TODO: Extremely simple persistance. Upgrade to protobuf / encrypt / etc.
     # TODO: Allow for wallets to be removed / modified?
     # TODO: Consider error handling in the new version
+    # NOTE: wallet_path being configurable is essential for testing
     ADDRESS_TYPE_XMSS = 'XMSS'
 
-    def __init__(self):
+    def __init__(self, wallet_path=config.user.wallet_path):
         """
         >>> Wallet().address_bundle is not None
         True
         """
-        config.create_path(config.user.wallet_path)
-        self.wallet_dat_filename = os.path.join(config.user.wallet_path, config.dev.wallet_dat_filename)
-        self.slave_dat_filename = os.path.join(config.user.wallet_path, config.dev.slave_dat_filename)
+        config.create_path(wallet_path)
+        self.wallet_dat_filename = os.path.join(wallet_path, config.dev.wallet_dat_filename)
+        self.slave_dat_filename = os.path.join(wallet_path, config.dev.slave_dat_filename)
 
         self.address_bundle = None
         self._read_wallet()


### PR DESCRIPTION
Wallet taking an arbitrary directory is very useful for integration tests.

Includes PR for Qaddress balances, but will be obsoleted by NodeInterface.