### PR TITLE
Updating Latest Transaction List from last state before rollback

### DIFF
--- a/tests/services/test_PublicAPIService.py
+++ b/tests/services/test_PublicAPIService.py
@@ -340,9 +340,9 @@ class TestPublicAPI(TestCase):
         # Verify transactions_unconfirmed
         self.assertEqual(3, len(response.transactions_unconfirmed))
         # TODO: Verify expected order
-        self.assertEqual(1011, response.transactions_unconfirmed[0].tx.transfer.amount)
+        self.assertEqual(1013, response.transactions_unconfirmed[0].tx.transfer.amount)
         self.assertEqual(1012, response.transactions_unconfirmed[1].tx.transfer.amount)
-        self.assertEqual(1013, response.transactions_unconfirmed[2].tx.transfer.amount)
+        self.assertEqual(1011, response.transactions_unconfirmed[2].tx.transfer.amount)
 
         # Verify transactions
         self.assertEqual(3, len(response.transactions))


### PR DESCRIPTION
Its a fix, for the sudden disappearance of latest transaction list, due to rollback or fork recovery.