### PR TITLE
Wallet address encoding fixes

### DIFF
--- a/qrl/core/Wallet.py
+++ b/qrl/core/Wallet.py
@@ -4,7 +4,7 @@
 from collections import namedtuple
 from typing import List
 
-from pyqrllib.pyqrllib import mnemonic2bin
+from pyqrllib.pyqrllib import mnemonic2bin, bin2hstr
 
 from qrl.generated import qrl_pb2
 from qrl.core import config
@@ -67,10 +67,10 @@ class Wallet:
                 for a in wallet_store.wallets:
                     tmpxmss = XMSS(config.dev.xmss_tree_height, mnemonic2bin(a.mnemonic.strip()))
                     tmpxmss.set_ots_index(a.xmss_index)
-                    if a.address.encode() != tmpxmss.address:
+                    if a.address != bin2hstr(tmpxmss.address).encode():
                         logger.fatal("Mnemonic and address do not match.")
                         exit(1)
-                    self.address_bundle.append(AddressBundle(tmpxmss.address, tmpxmss))
+                    self.address_bundle.append(AddressBundle(a.address, tmpxmss))
 
         except Exception as e:
             logger.warning("It was not possible to open the wallet: %s", e)
@@ -104,4 +104,4 @@ class Wallet:
         :return: a wallet address
         """
         xmss = XMSS(tree_height=signature_tree_height, seed=seed)
-        return AddressBundle(xmss.address, xmss)
+        return AddressBundle(bin2hstr(xmss.address).encode(), xmss)


### PR DESCRIPTION
Address encoding fix was required to support new address format.