### PR TITLE
Fixes

### DIFF
--- a/qrl/core/Miner.py
+++ b/qrl/core/Miner.py
@@ -66,7 +66,7 @@ class Miner(Qryptominer):
             self._master_address = self._slaves[0]
             unused_ots_found = False
             for slave_seed in self._slaves[1]:
-                xmss = Wallet.get_new_address(seed=slave_seed).xmss
+                xmss = Wallet.get_new_address(signature_tree_height=None, seed=slave_seed).xmss
                 addr_state = self.state.get_address(xmss.address)
                 if self.set_unused_ots_key(xmss, addr_state):  # Unused ots_key_found
                     self._mining_xmss = xmss

--- a/qrl/core/Wallet.py
+++ b/qrl/core/Wallet.py
@@ -103,9 +103,11 @@ class Wallet:
         :return: a wallet address
         """
         # FIXME: This should be always using the extended seed instead
-        if seed is None:
-            xmss = XMSS.from_height(signature_tree_height)
-        else:
+        if seed and signature_tree_height:
             xmss = XMSS(XmssFast(seed, signature_tree_height))
+        elif seed:
+            xmss = XMSS.from_extended_seed(seed)
+        else:
+            xmss = XMSS.from_height(signature_tree_height)
 
         return AddressBundle(bin2hstr(xmss.address).encode(), xmss)

--- a/qrl/crypto/xmss.py
+++ b/qrl/crypto/xmss.py
@@ -263,9 +263,9 @@ class XMSS(object):
         >>> from qrl.crypto.doctest_data import *
         >>> tmp = XMSS.from_extended_seed(xmss_test_eseed2)
         >>> bin2hstr( tmp.extended_seed )
-        '010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101'
+        '000200010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101'
         """
-        return self._xmss.getSeed()
+        return self._xmss.getExtendedSeed()
 
     @property
     def seed(self):

--- a/qrl/main.py
+++ b/qrl/main.py
@@ -83,7 +83,7 @@ def mining_wallet_checks(args):
 
     if args.randomizeSlaveXMSS:
         addrBundle = Wallet.get_new_address()
-        slaves = [bin2hstr(addrBundle.xmss.address), [addrBundle.xmss.seed], None]
+        slaves = [bin2hstr(addrBundle.xmss.address), [addrBundle.xmss.extended_seed], None]
         write_slaves(slaves_filename, slaves)
 
     try:
@@ -98,16 +98,17 @@ def mining_wallet_checks(args):
             seed = input('Enter hex or mnemonic seed of mining wallet ').encode()
         except KeyboardInterrupt:
             quit(0)
-        if len(seed) == 96:  # hexseed
+
+        if len(seed) == 102:  # hexseed
             bin_seed = hstr2bin(seed.decode())
-        elif len(seed.split()) == 32:
+        elif len(seed.split()) == 34:
             bin_seed = mnemonic2bin(seed.decode())
         else:
             logger.warning('Invalid XMSS seed')
             quit(1)
 
-        addrBundle = Wallet.get_new_address(seed=bin_seed)
-        slaves = [bin2hstr(addrBundle.xmss.address), [addrBundle.xmss.seed], None]
+        addrBundle = Wallet.get_new_address(signature_tree_height=None, seed=bin_seed)
+        slaves = [bin2hstr(addrBundle.xmss.address), [addrBundle.xmss.extended_seed], None]
         write_slaves(slaves_filename, slaves)
         slaves = read_slaves(slaves_filename)
     except KeyboardInterrupt:

--- a/tests/misc/helper.py
+++ b/tests/misc/helper.py
@@ -300,13 +300,13 @@ def get_slaves(alice_ots_index, txn_nonce):
     slave_txn._data.nonce = txn_nonce
     slave_txn.sign(alice_xmss)
 
-    slave_data = json.loads(json.dumps([bin2hstr(alice_xmss.address), [slave_xmss.seed], slave_txn.to_json()]))
+    slave_data = json.loads(json.dumps([bin2hstr(alice_xmss.address), [slave_xmss.extended_seed], slave_txn.to_json()]))
     slave_data[0] = bytes(hstr2bin(slave_data[0]))
     return slave_data
 
 
 def get_random_master():
     random_master = get_random_xmss(config.dev.xmss_tree_height)
-    slave_data = json.loads(json.dumps([bin2hstr(random_master.address), [random_master.seed], None]))
+    slave_data = json.loads(json.dumps([bin2hstr(random_master.address), [random_master.extended_seed], None]))
     slave_data[0] = bytes(hstr2bin(slave_data[0]))
     return slave_data


### PR DESCRIPTION
1. Node bootstrap, generating mining XMSS using mnemonic or extended seed.
2. XMSS.extendedSeed fixed now returns extendedSeed instead of seed.
3. Updates to Unit Test to use extendedSeed instead of seed.