### PR TITLE
cli: wallet_ls outputs double Q

### DIFF
--- a/qrl/cli.py
+++ b/qrl/cli.py
@@ -89,13 +89,13 @@ def _serialize_output(ctx, addresses: List[OutputMessage], source_description) -
             if ctx.obj.json:
                 msg['wallets'].append({'number': pos, 'address': item.decode(), 'balance': balance})
             else:
-                click.echo('{:<8}Q{:<83}{:5.8f}'.format(pos, item.decode(), balance))
+                click.echo('{:<8}{:<83}{:5.8f}'.format(pos, item.decode(), balance))
         except Exception as e:
             if ctx.obj.json:
                 msg['error'] = str(e)
                 msg['wallets'].append({'number': pos, 'address': item.decode(), 'balance': '?'})
             else:
-                click.echo('{:<8}Q{:<83}?'.format(pos, item.address))
+                click.echo('{:<8}{:<83}?'.format(pos, item.address))
 
 
 def _print_addresses(ctx, addresses: List[OutputMessage], source_description):


### PR DESCRIPTION
```
(qrl) shinichi@ilya-linux:~/QRL [master*]$ python qrl/cli.py wallet_ls
Wallet at          : /home/shinichi/QRL
Number  Address                                                                            Balance
---------------------------------------------------------------------------------------------------
0       QQ0106005f5d9ad541d19284af85de296e78c3547af5350adf21524bb63d290846a426be054cafa5    ?
```