### PR TITLE
Allowed use of any random XMSS for mining for master wallet

### DIFF
--- a/qrl/core/config.py
+++ b/qrl/core/config.py
@@ -24,6 +24,7 @@ class UserConfig(object):
         # Default configuration
         self.mining_enabled = True
         self.mining_thread_count = 0  # 0 to auto detect thread count based on CPU/GPU number of processors
+        self.random_mining_xmss_height = 6  # Height for the randomly generated XMSS used for mining
 
         # Ephemeral Configuration
         self.accept_ephemeral = True

--- a/qrl/core/node.py
+++ b/qrl/core/node.py
@@ -32,7 +32,7 @@ class POW(ConsensusMechanism):
                  p2p_factory,
                  sync_state: SyncState,
                  time_provider,
-                 slaves: list,
+                 mining_credit_wallet: bytes,
                  mining_thread_count):
 
         super().__init__(chain_manager)
@@ -40,13 +40,13 @@ class POW(ConsensusMechanism):
         self.time_provider = time_provider
 
         self.miner_toggler = False
-        self.slaves = slaves
+        self.mining_credit_wallet = mining_credit_wallet
 
         self.p2p_factory = p2p_factory  # FIXME: Decouple from p2pFactory. Comms vs node logic
         self.p2p_factory.pow = self  # FIXME: Temporary hack to keep things working while refactoring
 
         self.miner = Miner(self.pre_block_logic,
-                           self.slaves,
+                           self.mining_credit_wallet,
                            self.chain_manager.state,
                            mining_thread_count,
                            self.p2p_factory.add_unprocessed_txn)

--- a/qrl/core/qrlnode.py
+++ b/qrl/core/qrlnode.py
@@ -32,7 +32,7 @@ from qrl.generated import qrl_pb2
 
 
 class QRLNode:
-    def __init__(self, db_state: State, slaves: list):
+    def __init__(self, db_state: State, mining_credit_wallet: bytes):
         self.start_time = time.time()
         self.db_state = db_state
         self._sync_state = SyncState()
@@ -50,7 +50,7 @@ class QRLNode:
 
         self._pow = None
 
-        self.slaves = slaves
+        self.mining_credit_wallet = mining_credit_wallet
 
         self.banned_peers_filename = os.path.join(config.user.wallet_dir, config.dev.banned_peers_filename)
 
@@ -236,7 +236,7 @@ class QRLNode:
                         p2p_factory=self._p2pfactory,
                         sync_state=self._sync_state,
                         time_provider=ntp,
-                        slaves=self.slaves,
+                        mining_credit_wallet=self.mining_credit_wallet,
                         mining_thread_count=mining_thread_count)
 
         self._pow.start()

--- a/tests/blockchain/MockedBlockchain.py
+++ b/tests/blockchain/MockedBlockchain.py
@@ -96,7 +96,7 @@ class MockedBlockchain(object):
 
                 chain_manager._difficulty_tracker.get = MagicMock(return_value=(tmp_difficulty, tmp_target))
 
-                qrlnode = QRLNode(state, slaves=[])
+                qrlnode = QRLNode(state, mining_credit_wallet=b'')
                 qrlnode.set_chain_manager(chain_manager)
 
                 mock_blockchain = MockedBlockchain(qrlnode, time_mock, ntp_mock, )

--- a/tests/core/test_node.py
+++ b/tests/core/test_node.py
@@ -7,7 +7,7 @@ from unittest import TestCase
 from mock import Mock, MagicMock
 from pyqryptonight.pyqryptonight import StringToUInt256
 
-from tests.misc.helper import get_slaves, get_alice_xmss, get_random_master
+from tests.misc.helper import get_alice_xmss, get_random_xmss
 from qrl.core import config
 from qrl.core.misc import logger
 from qrl.core.AddressState import AddressState
@@ -42,7 +42,7 @@ class TestNode(TestCase):
                    p2p_factory=p2p_factory,
                    sync_state=sync_state,
                    time_provider=time_provider,
-                   slaves=get_slaves(0, 0),
+                   mining_credit_wallet=get_random_xmss().address,
                    mining_thread_count=0)
 
         self.assertIsNotNone(node)
@@ -57,7 +57,7 @@ class TestNode(TestCase):
                    p2p_factory=p2p_factory,
                    sync_state=sync_state,
                    time_provider=time_provider,
-                   slaves=get_slaves(0, 0),
+                   mining_credit_wallet=get_random_xmss().address,
                    mining_thread_count=0)
 
         self.assertIsNotNone(node)
@@ -74,7 +74,7 @@ class TestNode(TestCase):
                    p2p_factory=p2p_factory,
                    sync_state=sync_state,
                    time_provider=time_provider,
-                   slaves=get_slaves(0, 0),
+                   mining_credit_wallet=get_random_xmss().address,
                    mining_thread_count=0)
 
         self.assertIsNotNone(node)
@@ -107,7 +107,7 @@ class TestNode(TestCase):
                        p2p_factory=p2p_factory,
                        sync_state=sync_state,
                        time_provider=time_provider,
-                       slaves=get_random_master(),
+                       mining_credit_wallet=get_random_xmss().address,
                        mining_thread_count=0)
 
             self.assertIsNotNone(node)
@@ -124,7 +124,7 @@ class TestNode(TestCase):
                    p2p_factory=p2p_factory,
                    sync_state=sync_state,
                    time_provider=time_provider,
-                   slaves=get_slaves(0, 0),
+                   mining_credit_wallet=get_random_xmss().address,
                    mining_thread_count=0)
 
         self.assertIsNotNone(node)

--- a/tests/services/test_BaseService.py
+++ b/tests/services/test_BaseService.py
@@ -22,7 +22,7 @@ class TestBaseAPI(TestCase):
 
     def test_getNodeInfo(self):
         db_state = Mock(spec=State)
-        qrlnode = QRLNode(db_state, slaves=[])
+        qrlnode = QRLNode(db_state, mining_credit_wallet=b'')
 
         service = BaseService(qrlnode)
         response = service.GetNodeInfo(request=GetNodeInfoReq, context=None)

--- a/tests/services/test_PublicAPIService.py
+++ b/tests/services/test_PublicAPIService.py
@@ -40,7 +40,7 @@ class TestPublicAPI(TestCase):
         chain_manager = Mock(spec=ChainManager)
         chain_manager.height = 0
 
-        qrlnode = QRLNode(db_state, slaves=[])
+        qrlnode = QRLNode(db_state, mining_credit_wallet=b'')
         qrlnode.set_chain_manager(chain_manager)
         qrlnode._p2pfactory = p2p_factory
         qrlnode._pow = p2p_factory.pow
@@ -63,7 +63,7 @@ class TestPublicAPI(TestCase):
         chain_manager = Mock(spec=ChainManager)
         chain_manager.height = 0
 
-        qrlnode = QRLNode(db_state, slaves=[])
+        qrlnode = QRLNode(db_state, mining_credit_wallet=b'')
         qrlnode.set_chain_manager(chain_manager)
         qrlnode._p2pfactory = p2p_factory
         qrlnode._pow = p2p_factory.pow
@@ -94,7 +94,7 @@ class TestPublicAPI(TestCase):
         chain_manager.get_block_by_number = MagicMock(return_value=None)
         chain_manager.state = db_state
 
-        qrlnode = QRLNode(db_state, slaves=[])
+        qrlnode = QRLNode(db_state, mining_credit_wallet=b'')
         qrlnode.set_chain_manager(chain_manager)
         qrlnode._p2pfactory = p2p_factory
         qrlnode._pow = p2p_factory.pow
@@ -135,7 +135,7 @@ class TestPublicAPI(TestCase):
         p2p_factory = Mock(spec=P2PFactory)
         chain_manager = ChainManager(db_state)
 
-        qrlnode = QRLNode(db_state, slaves=[])
+        qrlnode = QRLNode(db_state, mining_credit_wallet=b'')
         qrlnode.set_chain_manager(chain_manager)
         qrlnode._p2pfactory = p2p_factory
         qrlnode._peer_addresses = ['127.0.0.1', '192.168.1.1']
@@ -172,7 +172,7 @@ class TestPublicAPI(TestCase):
 
         chain_manager = ChainManager(db_state)
 
-        qrlnode = QRLNode(db_state, slaves=[])
+        qrlnode = QRLNode(db_state, mining_credit_wallet=b'')
         qrlnode.set_chain_manager(chain_manager)
         qrlnode._p2pfactory = p2p_factory
         qrlnode._pow = p2p_factory.pow
@@ -308,7 +308,7 @@ class TestPublicAPI(TestCase):
         chain_manager.tx_pool.transaction_pool = txpool
         chain_manager.height = len(blocks)
 
-        qrlnode = QRLNode(db_state, slaves=[])
+        qrlnode = QRLNode(db_state, mining_credit_wallet=b'')
         qrlnode.set_chain_manager(chain_manager)
         qrlnode.get_block_from_index = MagicMock(return_value=None)
 
@@ -360,7 +360,7 @@ class TestPublicAPI(TestCase):
         chain_manager = Mock(spec=ChainManager)
         chain_manager.height = 0
 
-        qrlnode = QRLNode(db_state, slaves=[])
+        qrlnode = QRLNode(db_state, mining_credit_wallet=b'')
         qrlnode.set_chain_manager(chain_manager)
         qrlnode._p2pfactory = p2p_factory
         qrlnode._pow = p2p_factory.pow

--- a/tests/services/test_PublicAPIService_transfer.py
+++ b/tests/services/test_PublicAPIService_transfer.py
@@ -33,7 +33,7 @@ class TestPublicAPI(TestCase):
                     p2p_factory.pow = Mock(spec=POW)
                     chain_manager = ChainManager(db_state)
 
-                    qrlnode = QRLNode(db_state, slaves=[])
+                    qrlnode = QRLNode(db_state, mining_credit_wallet=b'')
                     qrlnode.set_chain_manager(chain_manager)
                     qrlnode._p2pfactory = p2p_factory
                     qrlnode._pow = p2p_factory.pow
@@ -79,7 +79,7 @@ class TestPublicAPI(TestCase):
                     p2p_factory.pow = Mock(spec=POW)
                     chain_manager = ChainManager(db_state)
 
-                    qrlnode = QRLNode(db_state, slaves=[])
+                    qrlnode = QRLNode(db_state, mining_credit_wallet=b'')
                     qrlnode.set_chain_manager(chain_manager)
                     qrlnode._p2pfactory = p2p_factory
                     qrlnode._pow = p2p_factory.pow
@@ -133,7 +133,7 @@ class TestPublicAPI(TestCase):
                     p2p_factory.pow = Mock(spec=POW)
                     chain_manager = ChainManager(db_state)
 
-                    qrlnode = QRLNode(db_state, slaves=[])
+                    qrlnode = QRLNode(db_state, mining_credit_wallet=b'')
                     qrlnode.set_chain_manager(chain_manager)
                     qrlnode._p2pfactory = p2p_factory
                     qrlnode._pow = p2p_factory.pow


### PR DESCRIPTION
1> Any random XMSS can be used to mine for any wallet.
2> miningCreditWallet has to be specified before a node starts. And node will generate some random XMSS used for signing coinbase txn, but reward will be credited to the wallet address mentioned in miningCreditWallet.
3> random_mining_xmss_height in config.py can be used to control the height of random mining XMSS.