### PR TITLE
Bug Fix: Frequently Changing mining_block_template & submitblock api response

### DIFF
--- a/src/qrl/core/ChainManager.py
+++ b/src/qrl/core/ChainManager.py
@@ -202,8 +202,6 @@ class ChainManager:
     def _try_orphan_add_block(self, block, batch):
         prev_block_metadata = self.state.get_block_metadata(block.prev_headerhash)
 
-        self.trigger_miner = False
-
         if prev_block_metadata is None or prev_block_metadata.is_orphan:
             self.state.put_block(block, batch)
             self.add_block_metadata(block.headerhash, block.timestamp, block.prev_headerhash, batch)
@@ -232,7 +230,6 @@ class ChainManager:
             last_block_difficulty = int(UInt256ToString(last_block_metadata.cumulative_difficulty))
             new_block_difficulty = int(UInt256ToString(new_block_metadata.cumulative_difficulty))
 
-            self.trigger_miner = False
             if new_block_difficulty > last_block_difficulty:
                 if self.last_block.headerhash != block.prev_headerhash:
                     self.rollback(block)
@@ -289,6 +286,8 @@ class ChainManager:
         self.trigger_miner = True
 
     def _add_block(self, block, ignore_duplicate=False, batch=None):
+        self.trigger_miner = False
+
         block_size_limit = self.state.get_block_size_limit(block)
         if block_size_limit and block.size > block_size_limit:
             logger.info('Block Size greater than threshold limit %s > %s', block.size, block_size_limit)

--- a/src/qrl/core/node.py
+++ b/src/qrl/core/node.py
@@ -205,7 +205,7 @@ class POW(ConsensusMechanism):
             result = self.chain_manager.add_block(block)
 
             logger.debug('trigger_miner %s', self.chain_manager.trigger_miner)
-            if self.chain_manager.trigger_miner or not self.miner.isRunning():
+            if self.chain_manager.trigger_miner:
                 self.mine_next(self.chain_manager.last_block)
 
             if not result:

--- a/src/qrl/grpcProxy.py
+++ b/src/qrl/grpcProxy.py
@@ -171,6 +171,8 @@ def submitblock(blob):
     stub = get_mining_stub()
     request = qrlmining_pb2.SubmitMinedBlockReq(blob=bytes(hstr2bin(blob)))
     response = stub.SubmitMinedBlock(request=request, timeout=10)
+    if response.error:
+        raise Exception  # Mining pool expected exception when block submission fails
     return MessageToJson(response)
 
 


### PR DESCRIPTION
1> Mining_block_template was changing frequently each time a block is successfully added that belongs to some different chain but not the main chain.
2> When block submitted by pool is not valid, pool expects error to be thrown by the API