### PR TITLE
Fix: Orphan Block logic, adding duplicate child headerhash

### DIFF
--- a/src/qrl/core/BlockMetadata.py
+++ b/src/qrl/core/BlockMetadata.py
@@ -48,13 +48,19 @@ class BlockMetadata(object):
         self._data.cumulative_difficulty = bytes(value)
 
     def add_child_headerhash(self, child_headerhash: bytes):
-        self._data.child_headerhashes.append(child_headerhash)
+        if child_headerhash not in self._data.child_headerhashes:
+            self._data.child_headerhashes.append(child_headerhash)
 
     def update_last_headerhashes(self, parent_last_N_headerhashes, last_headerhash: bytes):
         self._data.last_N_headerhashes.extend(parent_last_N_headerhashes)
         self._data.last_N_headerhashes.append(last_headerhash)
         if len(self._data.last_N_headerhashes) > config.dev.N_measurement:
             del self._data.last_N_headerhashes[0]
+
+        if len(self._data.last_N_headerhashes) > config.dev.N_measurement:
+            raise Exception('Size of last_N_headerhashes is more than expected %s %s',
+                            len(self._data.last_N_headerhashes),
+                            config.dev.N_measurement)
 
     @staticmethod
     def create(is_orphan=True,

--- a/tests/blockchain/MockedBlockchain.py
+++ b/tests/blockchain/MockedBlockchain.py
@@ -97,7 +97,7 @@ class MockedBlockchain(object):
                 qrlnode = QRLNode(state, mining_credit_wallet=b'')
                 qrlnode.set_chain_manager(chain_manager)
 
-                mock_blockchain = MockedBlockchain(qrlnode, time_mock, ntp_mock, )
+                mock_blockchain = MockedBlockchain(qrlnode, time_mock, ntp_mock)
                 for block_idx in range(1, num_blocks + 1):
                     mock_blockchain.add_new_block()
 

--- a/tests/core/test_ChainManager.py
+++ b/tests/core/test_ChainManager.py
@@ -311,5 +311,9 @@ class TestChainManager(TestCase):
                     block = state.get_block(block.headerhash)
                     self.assertIsNotNone(block)
 
+                    self.assertEqual(len(state.get_block_metadata(block_1.headerhash).child_headerhashes), 0)
+                    self.assertEqual(len(state.get_block_metadata(block.headerhash).child_headerhashes), 1)
+                    self.assertEqual(len(state.get_block_metadata(block_2.headerhash).child_headerhashes), 0)
+
                     self.assertEqual(chain_manager.last_block.block_number, block_2.block_number)
                     self.assertEqual(chain_manager.last_block.headerhash, block_2.headerhash)


### PR DESCRIPTION
Orphan Block Logic, adding duplicate child headerhash, resulting into duplicated last_N_headerhashes which changes the value of get_measurement resulting into different difficulty and making block syncing fail.

Bug has been fixed into this PR, and unit test updated for the same.