### PR TITLE
Changed parameter miningCreditWallet to mining_address

### DIFF
--- a/src/qrl/core/Miner.py
+++ b/src/qrl/core/Miner.py
@@ -20,7 +20,7 @@ from qrl.core.misc import logger
 class Miner(Qryptominer):
     def __init__(self,
                  pre_block_logic,
-                 mining_credit_wallet: bytes,
+                 mining_address: bytes,
                  state: State,
                  mining_thread_count,
                  add_unprocessed_txn_fn):
@@ -32,7 +32,7 @@ class Miner(Qryptominer):
         self._current_target = None
         self._measurement = None  # Required only for logging
 
-        self._mining_credit_wallet = mining_credit_wallet
+        self._mining_address = mining_address
         self._reward_address = None
         self.state = state
         self._add_unprocessed_txn_fn = add_unprocessed_txn_fn
@@ -45,7 +45,7 @@ class Miner(Qryptominer):
             self._mining_block = self.create_block(last_block=parent_block,
                                                    mining_nonce=0,
                                                    tx_pool=tx_pool,
-                                                   miner_address=self._mining_credit_wallet)
+                                                   miner_address=self._mining_address)
 
             parent_metadata = self.state.get_block_metadata(parent_block.headerhash)
             self._measurement = self.state.get_measurement(self._mining_block.timestamp,

--- a/src/qrl/core/config.py
+++ b/src/qrl/core/config.py
@@ -23,6 +23,7 @@ class UserConfig(object):
 
         # Default configuration
         self.mining_enabled = True
+        self.mining_address = b''
         self.mining_thread_count = 0  # 0 to auto detect thread count based on CPU/GPU number of processors
 
         # Ephemeral Configuration

--- a/src/qrl/core/node.py
+++ b/src/qrl/core/node.py
@@ -32,7 +32,7 @@ class POW(ConsensusMechanism):
                  p2p_factory,
                  sync_state: SyncState,
                  time_provider,
-                 mining_credit_wallet: bytes,
+                 mining_address: bytes,
                  mining_thread_count):
 
         super().__init__(chain_manager)
@@ -40,13 +40,13 @@ class POW(ConsensusMechanism):
         self.time_provider = time_provider
 
         self.miner_toggler = False
-        self.mining_credit_wallet = mining_credit_wallet
+        self.mining_address = mining_address
 
         self.p2p_factory = p2p_factory  # FIXME: Decouple from p2pFactory. Comms vs node logic
         self.p2p_factory.pow = self  # FIXME: Temporary hack to keep things working while refactoring
 
         self.miner = Miner(self.pre_block_logic,
-                           self.mining_credit_wallet,
+                           self.mining_address,
                            self.chain_manager.state,
                            mining_thread_count,
                            self.p2p_factory.add_unprocessed_txn)

--- a/src/qrl/core/qrlnode.py
+++ b/src/qrl/core/qrlnode.py
@@ -32,7 +32,7 @@ from qrl.generated import qrl_pb2
 
 
 class QRLNode:
-    def __init__(self, db_state: State, mining_credit_wallet: bytes):
+    def __init__(self, db_state: State, mining_address: bytes):
         self.start_time = time.time()
         self.db_state = db_state
         self._sync_state = SyncState()
@@ -50,7 +50,7 @@ class QRLNode:
 
         self._pow = None
 
-        self.mining_credit_wallet = mining_credit_wallet
+        self.mining_address = mining_address
 
         self.banned_peers_filename = os.path.join(config.user.wallet_dir, config.dev.banned_peers_filename)
 
@@ -236,7 +236,7 @@ class QRLNode:
                         p2p_factory=self._p2pfactory,
                         sync_state=self._sync_state,
                         time_provider=ntp,
-                        mining_credit_wallet=self.mining_credit_wallet,
+                        mining_address=self.mining_address,
                         mining_thread_count=mining_thread_count)
 
         self._pow.start()

--- a/tests/blockchain/MockedBlockchain.py
+++ b/tests/blockchain/MockedBlockchain.py
@@ -94,7 +94,7 @@ class MockedBlockchain(object):
 
                 chain_manager._difficulty_tracker.get = MagicMock(return_value=(tmp_difficulty, tmp_target))
 
-                qrlnode = QRLNode(state, mining_credit_wallet=b'')
+                qrlnode = QRLNode(state, mining_address=b'')
                 qrlnode.set_chain_manager(chain_manager)
 
                 mock_blockchain = MockedBlockchain(qrlnode, time_mock, ntp_mock)

--- a/tests/core/test_node.py
+++ b/tests/core/test_node.py
@@ -42,7 +42,7 @@ class TestNode(TestCase):
                    p2p_factory=p2p_factory,
                    sync_state=sync_state,
                    time_provider=time_provider,
-                   mining_credit_wallet=get_random_xmss().address,
+                   mining_address=get_random_xmss().address,
                    mining_thread_count=0)
 
         self.assertIsNotNone(node)
@@ -57,7 +57,7 @@ class TestNode(TestCase):
                    p2p_factory=p2p_factory,
                    sync_state=sync_state,
                    time_provider=time_provider,
-                   mining_credit_wallet=get_random_xmss().address,
+                   mining_address=get_random_xmss().address,
                    mining_thread_count=0)
 
         self.assertIsNotNone(node)
@@ -74,7 +74,7 @@ class TestNode(TestCase):
                    p2p_factory=p2p_factory,
                    sync_state=sync_state,
                    time_provider=time_provider,
-                   mining_credit_wallet=get_random_xmss().address,
+                   mining_address=get_random_xmss().address,
                    mining_thread_count=0)
 
         self.assertIsNotNone(node)
@@ -108,7 +108,7 @@ class TestNode(TestCase):
                        p2p_factory=p2p_factory,
                        sync_state=sync_state,
                        time_provider=time_provider,
-                       mining_credit_wallet=get_random_xmss().address,
+                       mining_address=get_random_xmss().address,
                        mining_thread_count=0)
 
             self.assertIsNotNone(node)
@@ -125,7 +125,7 @@ class TestNode(TestCase):
                    p2p_factory=p2p_factory,
                    sync_state=sync_state,
                    time_provider=time_provider,
-                   mining_credit_wallet=get_random_xmss().address,
+                   mining_address=get_random_xmss().address,
                    mining_thread_count=0)
 
         self.assertIsNotNone(node)

--- a/tests/services/test_BaseService.py
+++ b/tests/services/test_BaseService.py
@@ -22,7 +22,7 @@ class TestBaseAPI(TestCase):
 
     def test_getNodeInfo(self):
         db_state = Mock(spec=State)
-        qrlnode = QRLNode(db_state, mining_credit_wallet=b'')
+        qrlnode = QRLNode(db_state, mining_address=b'')
 
         service = BaseService(qrlnode)
         response = service.GetNodeInfo(request=GetNodeInfoReq, context=None)

--- a/tests/services/test_PublicAPIService.py
+++ b/tests/services/test_PublicAPIService.py
@@ -41,7 +41,7 @@ class TestPublicAPI(TestCase):
         chain_manager = Mock(spec=ChainManager)
         chain_manager.height = 0
 
-        qrlnode = QRLNode(db_state, mining_credit_wallet=b'')
+        qrlnode = QRLNode(db_state, mining_address=b'')
         qrlnode.set_chain_manager(chain_manager)
         qrlnode._p2pfactory = p2p_factory
         qrlnode._pow = p2p_factory.pow
@@ -64,7 +64,7 @@ class TestPublicAPI(TestCase):
         chain_manager = Mock(spec=ChainManager)
         chain_manager.height = 0
 
-        qrlnode = QRLNode(db_state, mining_credit_wallet=b'')
+        qrlnode = QRLNode(db_state, mining_address=b'')
         qrlnode.set_chain_manager(chain_manager)
         qrlnode._p2pfactory = p2p_factory
         qrlnode._pow = p2p_factory.pow
@@ -95,7 +95,7 @@ class TestPublicAPI(TestCase):
         chain_manager.get_block_by_number = MagicMock(return_value=None)
         chain_manager.state = db_state
 
-        qrlnode = QRLNode(db_state, mining_credit_wallet=b'')
+        qrlnode = QRLNode(db_state, mining_address=b'')
         qrlnode.set_chain_manager(chain_manager)
         qrlnode._p2pfactory = p2p_factory
         qrlnode._pow = p2p_factory.pow
@@ -136,7 +136,7 @@ class TestPublicAPI(TestCase):
         p2p_factory = Mock(spec=P2PFactory)
         chain_manager = ChainManager(db_state)
 
-        qrlnode = QRLNode(db_state, mining_credit_wallet=b'')
+        qrlnode = QRLNode(db_state, mining_address=b'')
         qrlnode.set_chain_manager(chain_manager)
         qrlnode._p2pfactory = p2p_factory
         qrlnode._peer_addresses = ['127.0.0.1', '192.168.1.1']
@@ -173,7 +173,7 @@ class TestPublicAPI(TestCase):
 
         chain_manager = ChainManager(db_state)
 
-        qrlnode = QRLNode(db_state, mining_credit_wallet=b'')
+        qrlnode = QRLNode(db_state, mining_address=b'')
         qrlnode.set_chain_manager(chain_manager)
         qrlnode._p2pfactory = p2p_factory
         qrlnode._pow = p2p_factory.pow
@@ -307,7 +307,7 @@ class TestPublicAPI(TestCase):
         chain_manager.tx_pool.transaction_pool = txpool
         chain_manager.height = len(blocks)
 
-        qrlnode = QRLNode(db_state, mining_credit_wallet=b'')
+        qrlnode = QRLNode(db_state, mining_address=b'')
         qrlnode.set_chain_manager(chain_manager)
         qrlnode.get_block_from_index = MagicMock(return_value=None)
 
@@ -359,7 +359,7 @@ class TestPublicAPI(TestCase):
         chain_manager = Mock(spec=ChainManager)
         chain_manager.height = 0
 
-        qrlnode = QRLNode(db_state, mining_credit_wallet=b'')
+        qrlnode = QRLNode(db_state, mining_address=b'')
         qrlnode.set_chain_manager(chain_manager)
         qrlnode._p2pfactory = p2p_factory
         qrlnode._pow = p2p_factory.pow

--- a/tests/services/test_PublicAPIService_transfer.py
+++ b/tests/services/test_PublicAPIService_transfer.py
@@ -34,7 +34,7 @@ class TestPublicAPI(TestCase):
                     p2p_factory.pow = Mock(spec=POW)
                     chain_manager = ChainManager(db_state)
 
-                    qrlnode = QRLNode(db_state, mining_credit_wallet=b'')
+                    qrlnode = QRLNode(db_state, mining_address=b'')
                     qrlnode.set_chain_manager(chain_manager)
                     qrlnode._p2pfactory = p2p_factory
                     qrlnode._pow = p2p_factory.pow
@@ -82,7 +82,7 @@ class TestPublicAPI(TestCase):
                     p2p_factory.pow = Mock(spec=POW)
                     chain_manager = ChainManager(db_state)
 
-                    qrlnode = QRLNode(db_state, mining_credit_wallet=b'')
+                    qrlnode = QRLNode(db_state, mining_address=b'')
                     qrlnode.set_chain_manager(chain_manager)
                     qrlnode._p2pfactory = p2p_factory
                     qrlnode._pow = p2p_factory.pow
@@ -137,7 +137,7 @@ class TestPublicAPI(TestCase):
                     p2p_factory.pow = Mock(spec=POW)
                     chain_manager = ChainManager(db_state)
 
-                    qrlnode = QRLNode(db_state, mining_credit_wallet=b'')
+                    qrlnode = QRLNode(db_state, mining_address=b'')
                     qrlnode.set_chain_manager(chain_manager)
                     qrlnode._p2pfactory = p2p_factory
                     qrlnode._pow = p2p_factory.pow


### PR DESCRIPTION
- Changed parameter miningCreditWallet to mining_address
- Moved mining_address from required to optional 
- Added to mining_addres into config, in case of no mining_address provided during node start, it will consider the value from the config.