### PR TITLE
Increased max_ots_tracking_index from 1024 to 2048

### DIFF
--- a/src/qrl/core/config.py
+++ b/src/qrl/core/config.py
@@ -137,7 +137,7 @@ class DevConfig(object):
 
         # Maximum number of ots index upto which OTS index should be tracked. Any OTS index above the specified value
         # will be managed by OTS Counter
-        self.max_ots_tracking_index = 1024                                  #
+        self.max_ots_tracking_index = 2048                                  #
         self.mining_nonce_offset = 39
         self.extra_nonce_offset = 43
         self.mining_blob_size = 84


### PR DESCRIPTION
Increased number of ots index that can be tracked from 1024 to 2048.