### PR TITLE
Added limit on the length of Token Name & Symbol

### DIFF
--- a/src/qrl/core/Transaction.py
+++ b/src/qrl/core/Transaction.py
@@ -670,6 +670,18 @@ class TokenTransaction(Transaction):
         return transaction
 
     def _validate_custom(self):
+        if len(self.symbol) > config.dev.max_token_symbol_length:
+            logger.warning('Token Symbol Length exceeds maximum limit')
+            logger.warning('Found Symbol Length %s', len(self.symbol))
+            logger.warning('Expected Symbol length %s', config.dev.max_token_symbol_length)
+            return False
+
+        if len(self.name) > config.dev.max_token_name_length:
+            logger.warning('Token Name Length exceeds maximum limit')
+            logger.warning('Found Name Length %s', len(self.symbol))
+            logger.warning('Expected Name length %s', config.dev.max_token_name_length)
+            return False
+
         if len(self.initial_balances) == 0:
             logger.warning('Invalid Token Transaction, without any initial balance')
             return False

--- a/src/qrl/core/config.py
+++ b/src/qrl/core/config.py
@@ -172,6 +172,12 @@ class DevConfig(object):
         self.transaction_multi_output_limit = 100
 
         # ======================================
+        #          TOKEN TRANSACTION
+        # ======================================
+        self.max_token_symbol_length = 10
+        self.max_token_name_length = 30
+
+        # ======================================
         #       DIFFICULTY CONTROLLER
         # ======================================
         self.N_measurement = 250


### PR DESCRIPTION
- Limited Token Name & Symbol length 
- Lengths are configurable via config.py
- Current length limit for Symbol is 10 and for Token Name is 30