### PR TITLE
Moving ots_counter value to last ots_counter during rollback

### DIFF
--- a/src/qrl/core/AddressState.py
+++ b/src/qrl/core/AddressState.py
@@ -162,14 +162,20 @@ class AddressState(object):
         else:
             self._data.ots_counter = ots_key_index
 
-    def unset_ots_key(self, ots_key_index):
+    def unset_ots_key(self, ots_key_index, state):
         if ots_key_index < config.dev.max_ots_tracking_index:
             offset = ots_key_index >> 3
             relative = ots_key_index % 8
             bitfield = bytearray(self._data.ots_bitfield[offset])
             self._data.ots_bitfield[offset] = bytes([bitfield[0] & ~(1 << relative)])
         else:
-            self._data.ots_counter = ots_key_index - 1
+            self._data.ots_counter = 0  # defaults to 0 in case, no other ots_key found for ots_counter
+            # Expected transaction hash has been removed before unsetting ots key for that same transaction
+            for tx_hash in self.transaction_hashes[-1::-1]:
+                tx, _ = state.get_tx_metadata(tx_hash)
+                if tx.ots_key >= config.dev.max_ots_tracking_index:
+                    self._data.ots_counter = tx.ots_key
+                    break
 
     @staticmethod
     def address_is_valid(address: bytes) -> bool:

--- a/src/qrl/core/ChainManager.py
+++ b/src/qrl/core/ChainManager.py
@@ -256,7 +256,7 @@ class ChainManager:
         addresses_state = self.state.get_state_mainchain(addresses_set)
         for tx_idx in range(len(block.transactions) - 1, 0, -1):
             tx = Transaction.from_pbdata(block.transactions[tx_idx])
-            tx.unapply_on_state(addresses_state)
+            tx.unapply_on_state(addresses_state, self.state)
 
         # TODO: Move txn from block to pool
         # self.tx_pool.add_tx_in_block_from_pool(block)

--- a/src/qrl/core/State.py
+++ b/src/qrl/core/State.py
@@ -162,7 +162,7 @@ class State:
             # Deplay transactions in reverse order, otherwise could result into negative value
             for tx_protobuf in block.transactions[-1::-1]:
                 tx = Transaction.from_pbdata(tx_protobuf)
-                tx.unapply_on_state(addresses_state)
+                tx.unapply_on_state(addresses_state, self)
             block = self.get_block(block.prev_headerhash)
 
         for header_hash in hash_path[-1::-1]:

--- a/src/qrl/core/Transaction.py
+++ b/src/qrl/core/Transaction.py
@@ -138,7 +138,7 @@ class Transaction(object, metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def unapply_on_state(self, addresses_state):
+    def unapply_on_state(self, addresses_state, state):
         """
         This method, unapplies the changes on the state caused by txn.
         :return:
@@ -370,7 +370,7 @@ class TransferTransaction(Transaction):
             addresses_state[addr_from_pk].increase_nonce()
             addresses_state[addr_from_pk].set_ots_key(self.ots_key)
 
-    def unapply_on_state(self, addresses_state):
+    def unapply_on_state(self, addresses_state, state):
         if self.addr_from in addresses_state:
             addresses_state[self.addr_from].balance += (self.total_amount + self.fee)
             addresses_state[self.addr_from].transaction_hashes.remove(self.txhash)
@@ -389,7 +389,7 @@ class TransferTransaction(Transaction):
             if self.addr_from != addr_from_pk:
                 addresses_state[addr_from_pk].transaction_hashes.remove(self.txhash)
             addresses_state[addr_from_pk].decrease_nonce()
-            addresses_state[addr_from_pk].unset_ots_key(self.ots_key)
+            addresses_state[addr_from_pk].unset_ots_key(self.ots_key, state)
 
     def set_effected_address(self, addresses_set: set):
         addresses_set.add(self.addr_from)
@@ -465,7 +465,7 @@ class CoinBase(Transaction):
             addresses_state[self.master_addr].transaction_hashes.append(self.txhash)
             addresses_state[addr_from].increase_nonce()
 
-    def unapply_on_state(self, addresses_state):
+    def unapply_on_state(self, addresses_state, state):
         if self.addr_to in addresses_state:
             addresses_state[self.addr_to].balance -= self.amount
             addresses_state[self.addr_to].transaction_hashes.remove(self.txhash)
@@ -561,7 +561,7 @@ class LatticePublicKey(Transaction):
             addresses_state[addr_from_pk].increase_nonce()
             addresses_state[addr_from_pk].set_ots_key(self.ots_key)
 
-    def unapply_on_state(self, addresses_state):
+    def unapply_on_state(self, addresses_state, state):
         if self.addr_from in addresses_state:
             addresses_state[self.addr_from].balance += self.fee
             addresses_state[self.addr_from].remove_lattice_pk(self)
@@ -572,7 +572,7 @@ class LatticePublicKey(Transaction):
             if self.addr_from != addr_from_pk:
                 addresses_state[addr_from_pk].transaction_hashes.remove(self.txhash)
             addresses_state[addr_from_pk].decrease_nonce()
-            addresses_state[addr_from_pk].unset_ots_key(self.ots_key)
+            addresses_state[addr_from_pk].unset_ots_key(self.ots_key, state)
 
     def set_effected_address(self, addresses_set: set):
         addresses_set.add(self.addr_from)
@@ -648,7 +648,7 @@ class MessageTransaction(Transaction):
             addresses_state[addr_from_pk].increase_nonce()
             addresses_state[addr_from_pk].set_ots_key(self.ots_key)
 
-    def unapply_on_state(self, addresses_state):
+    def unapply_on_state(self, addresses_state, state):
         if self.addr_from in addresses_state:
             addresses_state[self.addr_from].balance += self.fee
             addresses_state[self.addr_from].transaction_hashes.remove(self.txhash)
@@ -658,7 +658,7 @@ class MessageTransaction(Transaction):
             if self.addr_from != addr_from_pk:
                 addresses_state[addr_from_pk].transaction_hashes.remove(self.txhash)
             addresses_state[addr_from_pk].decrease_nonce()
-            addresses_state[addr_from_pk].unset_ots_key(self.ots_key)
+            addresses_state[addr_from_pk].unset_ots_key(self.ots_key, state)
 
     def set_effected_address(self, addresses_set: set):
         addresses_set.add(self.addr_from)
@@ -834,7 +834,7 @@ class TokenTransaction(Transaction):
             addresses_state[addr_from_pk].increase_nonce()
             addresses_state[addr_from_pk].set_ots_key(self.ots_key)
 
-    def unapply_on_state(self, addresses_state):
+    def unapply_on_state(self, addresses_state, state):
         addr_from_pk = bytes(QRLHelper.getAddress(self.PK))
         owner_processed = False
         addr_from_processed = False
@@ -868,7 +868,7 @@ class TokenTransaction(Transaction):
                 if not addr_from_pk_processed:
                     addresses_state[addr_from_pk].transaction_hashes.remove(self.txhash)
             addresses_state[addr_from_pk].decrease_nonce()
-            addresses_state[addr_from_pk].unset_ots_key(self.ots_key)
+            addresses_state[addr_from_pk].unset_ots_key(self.ots_key, state)
 
     def set_effected_address(self, addresses_set: set):
         addresses_set.add(self.addr_from)
@@ -1027,7 +1027,7 @@ class TransferTokenTransaction(Transaction):
             addresses_state[addr_from_pk].increase_nonce()
             addresses_state[addr_from_pk].set_ots_key(self.ots_key)
 
-    def unapply_on_state(self, addresses_state):
+    def unapply_on_state(self, addresses_state, state):
         if self.addr_from in addresses_state:
             addresses_state[self.addr_from].tokens[bin2hstr(self.token_txhash).encode()] += self.total_amount
             addresses_state[self.addr_from].balance += self.fee
@@ -1046,7 +1046,7 @@ class TransferTokenTransaction(Transaction):
             if self.addr_from != addr_from_pk:
                 addresses_state[addr_from_pk].transaction_hashes.remove(self.txhash)
             addresses_state[addr_from_pk].decrease_nonce()
-            addresses_state[addr_from_pk].unset_ots_key(self.ots_key)
+            addresses_state[addr_from_pk].unset_ots_key(self.ots_key, state)
 
     def set_effected_address(self, addresses_set: set):
         addresses_set.add(self.addr_from)
@@ -1153,7 +1153,7 @@ class SlaveTransaction(Transaction):
             addresses_state[addr_from_pk].increase_nonce()
             addresses_state[addr_from_pk].set_ots_key(self.ots_key)
 
-    def unapply_on_state(self, addresses_state):
+    def unapply_on_state(self, addresses_state, state):
         if self.addr_from in addresses_state:
             addresses_state[self.addr_from].balance += self.fee
             for index in range(0, len(self.slave_pks)):
@@ -1165,7 +1165,7 @@ class SlaveTransaction(Transaction):
             if self.addr_from != addr_from_pk:
                 addresses_state[addr_from_pk].transaction_hashes.remove(self.txhash)
             addresses_state[addr_from_pk].decrease_nonce()
-            addresses_state[addr_from_pk].unset_ots_key(self.ots_key)
+            addresses_state[addr_from_pk].unset_ots_key(self.ots_key, state)
 
     def set_effected_address(self, addresses_set: set):
         addresses_set.add(self.addr_from)


### PR DESCRIPTION
Instead of moving ots_counter value ots_key_index - 1, we now move the ots counter value to last ots_counter value, derived on the basis of the transaction related to the address.