### PR TITLE
fix mining timestamp vulnerability

### DIFF
--- a/src/qrl/core/Block.py
+++ b/src/qrl/core/Block.py
@@ -154,8 +154,8 @@ class Block(object):
 
         return self.blockheader.validate(fee_reward, coinbase_amount)
 
-    def validate_parent_child_relation(self, parent_block) -> bool:
-        return self.blockheader.validate_parent_child_relation(parent_block)
+    def validate_parent_child_relation(self, parent_block, median_timestamp) -> bool:
+        return self.blockheader.validate_parent_child_relation(parent_block, median_timestamp)
 
     def add_transaction(self, tx: Transaction):
         # TODO: Verify something basic here?

--- a/src/qrl/core/BlockHeader.py
+++ b/src/qrl/core/BlockHeader.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 import functools
+
 from google.protobuf.json_format import MessageToJson, Parse
 from pyqrllib.pyqrllib import shake128
 
@@ -178,12 +179,6 @@ class BlockHeader(object):
             logger.warning('threshold timestamp %s', allowed_timestamp)
             return False
 
-        if self.timestamp < config.dev.genesis_timestamp:
-            logger.warning('Timestamp lower than genesis timestamp')
-            logger.warning('Genesis Timestamp %s', config.dev.genesis_timestamp)
-            logger.warning('Block Timestamp %s', self.timestamp)
-            return False
-
         if self.generate_headerhash() != self.headerhash:
             logger.warning('Headerhash false for block: failed validation')
             return False
@@ -206,7 +201,7 @@ class BlockHeader(object):
 
         return True
 
-    def validate_parent_child_relation(self, parent_block):
+    def validate_parent_child_relation(self, parent_block, median_timestamp):
         if parent_block.block_number != self.block_number - 1:
             logger.warning('Block numbers out of sequence: failed validation')
             return False
@@ -215,11 +210,11 @@ class BlockHeader(object):
             logger.warning('Headerhash not in sequence: failed validation')
             return False
 
-        # if self.timestamp < parent_block.timestamp:
-        #    logger.warning('BLOCK timestamp is less than prev block timestamp')
-        #    logger.warning('block timestamp %s ', self.timestamp)
-        #    logger.warning('must be greater than or equals to %s', parent_block.timestamp)
-        #    return False
+        if self.timestamp < median_timestamp:
+            logger.warning('BLOCK timestamp is less than median timestamp')
+            logger.warning('block timestamp %s ', self.timestamp)
+            logger.warning('must be greater than or equals to %s', median_timestamp)
+            return False
 
         return True
 

--- a/src/qrl/core/BlockHeader.py
+++ b/src/qrl/core/BlockHeader.py
@@ -215,11 +215,11 @@ class BlockHeader(object):
             logger.warning('Headerhash not in sequence: failed validation')
             return False
 
-        if self.timestamp < parent_block.timestamp:
-            logger.warning('BLOCK timestamp is less than prev block timestamp')
-            logger.warning('block timestamp %s ', self.timestamp)
-            logger.warning('must be greater than or equals to %s', parent_block.timestamp)
-            return False
+        #if self.timestamp < parent_block.timestamp:
+        #    logger.warning('BLOCK timestamp is less than prev block timestamp')
+        #    logger.warning('block timestamp %s ', self.timestamp)
+        #    logger.warning('must be greater than or equals to %s', parent_block.timestamp)
+        #    return False
 
         return True
 

--- a/src/qrl/core/BlockHeader.py
+++ b/src/qrl/core/BlockHeader.py
@@ -215,7 +215,7 @@ class BlockHeader(object):
             logger.warning('Headerhash not in sequence: failed validation')
             return False
 
-        #if self.timestamp < parent_block.timestamp:
+        # if self.timestamp < parent_block.timestamp:
         #    logger.warning('BLOCK timestamp is less than prev block timestamp')
         #    logger.warning('block timestamp %s ', self.timestamp)
         #    logger.warning('must be greater than or equals to %s', parent_block.timestamp)

--- a/src/qrl/core/ChainManager.py
+++ b/src/qrl/core/ChainManager.py
@@ -214,7 +214,8 @@ class ChainManager:
 
     def _try_branch_add_block(self, block, batch=None) -> bool:
         parent_block = self.state.get_block(block.prev_headerhash)
-        if not block.validate_parent_child_relation(parent_block):
+        median_timestamp = self.state.get_n_block_median_timestamps(block)
+        if not block.validate_parent_child_relation(parent_block, median_timestamp):
             logger.warning('Failed to validate blocks parent child relation')
             return False
 

--- a/src/qrl/core/State.py
+++ b/src/qrl/core/State.py
@@ -523,3 +523,15 @@ class State:
                 data_point.hash_power = 0
 
         return data_point
+
+    def get_n_block_median_timestamps(self, current_block: Block):
+        timestamps = list()
+        block = current_block
+        i = 0
+        while i < config.dev.n_block_median_timestamps:
+            block = self.get_block(block.prev_headerhash)
+            timestamps.append(block.timestamp)
+            if block.block_number == 0:
+                break
+            i += 1
+        return int(median(timestamps))

--- a/src/qrl/core/config.py
+++ b/src/qrl/core/config.py
@@ -214,11 +214,12 @@ class DevConfig(object):
         self.kp = 5
 
         # ======================================
-        #       BLOCK SIZE CONTROLLER
+        #            BLOCK CONTROLLER
         # ======================================
         self.number_of_blocks_analyze = 10
         self.size_multiplier = 1.1
         self.block_min_size_limit = 1024 * 1024         # 1 MB - Initial Block Size Limit
+        self.n_block_median_timestamps = 12
 
         # ======================================
         # SHOR PER QUANTA / MAX ALLOWED DECIMALS


### PR DESCRIPTION
Timestamp checks were previously:
1) confirm new block < 120s into future compared with local node ntp-time
2) check that new block timestamp < previous block timestamp

It is possible for a modified client to mine blocks which are 120s into the future. In that situation untampered nodes would be unable to mine blocks on top of the block with a fraudulent timestamp as rule 2) would render such a block invalid. 

Following this strategy it is possible for a miner to win every block by faking the timestamps perpetually into the future. Removing this condition fixes the vulnerability. We can discuss a fix which allows variability in the timestamp in the blockheader in such a way that difficulty is unaffected, whilst not exposing a timestamp attack as detailed above.

A suggestion would be to follow bitcoin and set a rule where the timestamp of the next block must be > median of the last 11 blocks.