### PR TITLE
Removed peer list update on connection to peer

### DIFF
--- a/src/qrl/core/p2p/p2pPeerManager.py
+++ b/src/qrl/core/p2p/p2pPeerManager.py
@@ -44,12 +44,6 @@ class P2PPeerManager(P2PBaseObserver):
     def peer_addresses(self):
         return self._peer_addresses
 
-    def add_peer_addr(self, peer_add):
-        if peer_add not in self._peer_addresses:
-            logger.debug('Adding to peer_list')
-            self._peer_addresses.add(peer_add)
-            self.update_peer_addresses(self._peer_addresses)
-
     def load_peer_addresses(self) -> None:
         try:
             if os.path.isfile(self.peers_path):

--- a/src/qrl/core/p2p/p2pfactory.py
+++ b/src/qrl/core/p2p/p2pfactory.py
@@ -495,7 +495,6 @@ class P2PFactory(ServerFactory):
             return False
 
         self._peer_connections.append(conn_protocol)
-        self._qrl_node.add_peer(conn_protocol)
 
         logger.debug('>>> new connection: %s ', conn_protocol.addr_remote)
         return True

--- a/src/qrl/core/qrlnode.py
+++ b/src/qrl/core/qrlnode.py
@@ -160,9 +160,6 @@ class QRLNode:
         logger.warning('Banned %s', peer_obj.addr_remote)
         peer_obj.loseConnection()
 
-    def add_peer(self, peer_obj):
-        self.peer_manager.add_peer_addr(peer_obj.addr_remote)
-
     def connect_peers(self):
         logger.info('<<<Reconnecting to peer list: %s', self.peer_addresses)
         for peer_address in self.peer_addresses:


### PR DESCRIPTION
Peer is not added to the peer_list when connection is made. Rather peer_list is now only updated when connected peer shares the peer_list including its public port.