### PR TITLE
Fix: Mining Api GetBlockToMine

### DIFF
--- a/src/qrl/core/Block.py
+++ b/src/qrl/core/Block.py
@@ -142,12 +142,9 @@ class Block(object):
         for tx in self.transactions:
             hashedtransactions.append(tx.transaction_hash)
 
-        tmp_blockheader = BlockHeader.create(blocknumber=self.block_number,
-                                             prev_blockheaderhash=self.prev_headerhash,
-                                             hashedtransactions=merkle_tx_hash(hashedtransactions),
-                                             fee_reward=self.fee_reward)
+        self.blockheader.update_merkle_root(merkle_tx_hash(hashedtransactions))
 
-        self._data.header.MergeFrom(tmp_blockheader.pbdata)
+        self._data.header.MergeFrom(self.blockheader.pbdata)
 
     def validate(self) -> bool:
         fee_reward = 0

--- a/src/qrl/core/BlockHeader.py
+++ b/src/qrl/core/BlockHeader.py
@@ -145,6 +145,10 @@ class BlockHeader(object):
         bh.set_nonces(0, 0)
         return bh
 
+    def update_merkle_root(self, hashedtransactions: bytes):
+        self._data.merkle_root = hashedtransactions
+        self.set_nonces(0, 0)
+
     def set_nonces(self, mining_nonce, extra_nonce=0):
         self._data.mining_nonce = mining_nonce
         self._data.extra_nonce = extra_nonce

--- a/src/qrl/core/Miner.py
+++ b/src/qrl/core/Miner.py
@@ -156,7 +156,7 @@ class Miner(Qryptominer):
         mining_address = bytes(hstr2bin(wallet_address[1:]))
         if self._mining_block:
             if last_block.headerhash == self._mining_block.prev_headerhash:
-                if last_block.transactions[0].coinbase.addr_to == mining_address:
+                if self._mining_block.transactions[0].coinbase.addr_to == mining_address:
                     return [bin2hstr(self._mining_block.mining_blob),
                             int(bin2hstr(self._current_difficulty), 16)]
                 else:


### PR DESCRIPTION
Following bugs fixed
- Timestamp was being changed each time same mining block was requested.
- Comparison of miner address was being made from coinbase txn of previous block, while it has to be made by current mineable block.