### PR TITLE
Delay mining, while syncing blocks to mainchain

### DIFF
--- a/src/qrl/core/config.py
+++ b/src/qrl/core/config.py
@@ -255,6 +255,7 @@ class DevConfig(object):
         self.max_receivable_bytes = 10 * 1024 * 1024           # 10 MB [Temporary Restriction]
         self.reserved_quota = 1024                             # 1 KB
         self.max_bytes_out = self.max_receivable_bytes - self.reserved_quota
+        self.sync_delay_mining = 60  # Delay mining by 60 seconds while syncing blocks to mainchain
 
         # ======================================
         #            API SETTINGS

--- a/src/qrl/core/node.py
+++ b/src/qrl/core/node.py
@@ -58,6 +58,7 @@ class POW(ConsensusMechanism):
         self.last_pow_cycle = 0
         self.last_bk_time = 0
         self.last_pb_time = 0
+        self.suspend_mining_timestamp = 0
 
         self.epoch_diff = None
 
@@ -225,6 +226,8 @@ class POW(ConsensusMechanism):
         return False
 
     def mine_next(self, parent_block):
+        if ntp.getTime() < self.suspend_mining_timestamp:
+            return
         if config.user.mining_enabled:
             parent_metadata = self.chain_manager.state.get_block_metadata(parent_block.headerhash)
             self.miner.prepare_next_unmined_block_template(mining_address=self.mining_address,

--- a/src/qrl/core/p2p/p2pfactory.py
+++ b/src/qrl/core/p2p/p2pfactory.py
@@ -204,8 +204,10 @@ class P2PFactory(ServerFactory):
             logger.warning('Found headerhash %s', block.headerhash)
             return
 
-        # FIXME: This check should not be necessary
-        if not self._chain_manager.add_block(block):
+        if self._chain_manager.add_block(block):
+            if self._chain_manager.last_block.headerhash == block.headerhash:
+                self.pow.suspend_mining_timestamp = ntp.getTime() + config.dev.sync_delay_mining
+        else:
             logger.warning('Failed to Add Block')
             return
 


### PR DESCRIPTION
Mining gets delayed by 60 seconds while node is syncing blocks to mainchain. Each block added to the mainchain during syncing process adds T + 60 seconds, before mining could continue.