### PR TITLE
Create new block always ahead of parent block timestamp

### DIFF
--- a/src/qrl/core/Block.py
+++ b/src/qrl/core/Block.py
@@ -99,7 +99,8 @@ class Block(object):
 
     @staticmethod
     def create(block_number: int,
-               prevblock_headerhash: bytes,
+               prev_block_headerhash: bytes,
+               prev_block_timestamp: int,
                transactions: list,
                miner_address: bytes):
 
@@ -125,7 +126,8 @@ class Block(object):
         txs_hash = merkle_tx_hash(hashedtransactions)           # FIXME: Find a better name, type changes
 
         tmp_blockheader = BlockHeader.create(blocknumber=block_number,
-                                             prev_blockheaderhash=prevblock_headerhash,
+                                             prev_block_headerhash=prev_block_headerhash,
+                                             prev_block_timestamp=prev_block_timestamp,
                                              hashedtransactions=txs_hash,
                                              fee_reward=fee_reward)
 

--- a/src/qrl/core/BlockHeader.py
+++ b/src/qrl/core/BlockHeader.py
@@ -113,18 +113,21 @@ class BlockHeader(object):
 
     @staticmethod
     def create(blocknumber: int,
-               prev_blockheaderhash: bytes,
+               prev_block_headerhash: bytes,
+               prev_block_timestamp: int,
                hashedtransactions: bytes,
                fee_reward: int):
         """
         Create a block header based on the parameters
 
         >>> BlockHeader.create(blocknumber=1,
-        ...                    prev_blockheaderhash=b'headerhash',
+        ...                    prev_block_headerhash=b'headerhash',
+        ...                    prev_block_timestamp=10,
         ...                    hashedtransactions=b'some_data', fee_reward=1) is not None
         True
         >>> b=BlockHeader.create(blocknumber=1,
-        ...                      prev_blockheaderhash=b'headerhash',
+        ...                      prev_block_headerhash=b'headerhash',
+        ...                      prev_block_timestamp=10,
         ...                      hashedtransactions=b'some_data', fee_reward=1)
         >>> b.epoch
         0
@@ -135,11 +138,15 @@ class BlockHeader(object):
 
         if bh._data.block_number != 0:
             bh._data.timestamp_seconds = int(ntp.getTime())
+            # If current block timestamp is less than the previous block timestamp
+            # then set current block timestamp 1 sec higher than prev_block_timestamp
+            if bh._data.timestamp_seconds < prev_block_timestamp:
+                bh._data.timestamp_seconds = prev_block_timestamp + 1
             if bh._data.timestamp_seconds == 0:
                 logger.warning('Failed to get NTP timestamp')
                 return
 
-        bh._data.hash_header_prev = prev_blockheaderhash
+        bh._data.hash_header_prev = prev_block_headerhash
         bh._data.merkle_root = hashedtransactions
         bh._data.reward_fee = fee_reward
 

--- a/src/qrl/core/Miner.py
+++ b/src/qrl/core/Miner.py
@@ -103,7 +103,8 @@ class Miner(Qryptominer):
                      tx_pool: TransactionPool,
                      miner_address) -> Optional[Block]:
         dummy_block = Block.create(block_number=last_block.block_number + 1,
-                                   prevblock_headerhash=last_block.headerhash,
+                                   prev_block_headerhash=last_block.headerhash,
+                                   prev_block_timestamp=last_block.timestamp,
                                    transactions=[],
                                    miner_address=miner_address)
         dummy_block.set_nonces(mining_nonce, 0)
@@ -146,7 +147,8 @@ class Miner(Qryptominer):
             transactions.append(tx)
 
         block = Block.create(block_number=last_block.block_number + 1,
-                             prevblock_headerhash=last_block.headerhash,
+                             prev_block_headerhash=last_block.headerhash,
+                             prev_block_timestamp=last_block.timestamp,
                              transactions=transactions,
                              miner_address=miner_address)
 

--- a/tests/blockchain/MockedBlockchain.py
+++ b/tests/blockchain/MockedBlockchain.py
@@ -50,7 +50,8 @@ class MockedBlockchain(object):
         self.ntp_mock.return_value = self.ntp_mock.return_value + 60
 
         block_new = Block.create(block_number=block_idx,
-                                 prevblock_headerhash=block_prev.headerhash,
+                                 prev_block_headerhash=block_prev.headerhash,
+                                 prev_block_timestamp=block_prev.timestamp,
                                  transactions=transactions,
                                  miner_address=mining_address)
 

--- a/tests/core/test_ChainManager.py
+++ b/tests/core/test_ChainManager.py
@@ -54,7 +54,8 @@ class TestChainManager(TestCase):
                     time_mock.return_value = 1615270948  # Very high to get an easy difficulty
 
                     block_1 = Block.create(block_number=1,
-                                           prevblock_headerhash=genesis_block.headerhash,
+                                           prev_block_headerhash=genesis_block.headerhash,
+                                           prev_block_timestamp=genesis_block.timestamp,
                                            transactions=[],
                                            miner_address=alice_xmss.address)
                     block_1.set_nonces(258, 0)
@@ -106,7 +107,8 @@ class TestChainManager(TestCase):
                     time_mock.return_value = 1615270948  # Very high to get an easy difficulty
 
                     block_1 = Block.create(block_number=1,
-                                           prevblock_headerhash=genesis_block.headerhash,
+                                           prev_block_headerhash=genesis_block.headerhash,
+                                           prev_block_timestamp=genesis_block.timestamp,
                                            transactions=[transfer_transaction],
                                            miner_address=alice_xmss.address)
                     block_1.set_nonces(0, 0)
@@ -168,7 +170,8 @@ class TestChainManager(TestCase):
                     time_mock.return_value = 1615270948  # Very high to get an easy difficulty
 
                     block_1 = Block.create(block_number=1,
-                                           prevblock_headerhash=genesis_block.headerhash,
+                                           prev_block_headerhash=genesis_block.headerhash,
+                                           prev_block_timestamp=genesis_block.timestamp,
                                            transactions=[slave_tx],
                                            miner_address=alice_xmss.address)
                     block_1.set_nonces(3, 0)
@@ -190,7 +193,8 @@ class TestChainManager(TestCase):
                 with mock.patch('qrl.core.misc.ntp.getTime') as time_mock:
                     time_mock.return_value = 1715270948  # Very high to get an easy difficulty
                     block = Block.create(block_number=1,
-                                         prevblock_headerhash=genesis_block.headerhash,
+                                         prev_block_headerhash=genesis_block.headerhash,
+                                         prev_block_timestamp=genesis_block.timestamp,
                                          transactions=[],
                                          miner_address=bob_xmss.address)
 
@@ -211,7 +215,8 @@ class TestChainManager(TestCase):
                 with mock.patch('qrl.core.misc.ntp.getTime') as time_mock:
                     time_mock.return_value = 1815270948  # Very high to get an easy difficulty
                     block_2 = Block.create(block_number=2,
-                                           prevblock_headerhash=block.headerhash,
+                                           prev_block_headerhash=block.headerhash,
+                                           prev_block_timestamp=block.timestamp,
                                            transactions=[],
                                            miner_address=bob_xmss.address)
 
@@ -257,7 +262,8 @@ class TestChainManager(TestCase):
                     with mock.patch('qrl.core.misc.ntp.getTime') as time_mock:
                         time_mock.return_value = 1521889325  # Very high to get an easy difficulty
                         block_1 = Block.create(block_number=1,
-                                               prevblock_headerhash=genesis_block.headerhash,
+                                               prev_block_headerhash=genesis_block.headerhash,
+                                               prev_block_timestamp=genesis_block.timestamp,
                                                transactions=[],
                                                miner_address=alice_xmss.address)
                         block_1.set_nonces(21, 0)
@@ -276,7 +282,8 @@ class TestChainManager(TestCase):
                     with mock.patch('qrl.core.misc.ntp.getTime') as time_mock:
                         time_mock.return_value = 1521889326 + devconfig.minimum_minting_delay * 2
                         block = Block.create(block_number=1,
-                                             prevblock_headerhash=genesis_block.headerhash,
+                                             prev_block_headerhash=genesis_block.headerhash,
+                                             prev_block_timestamp=genesis_block.timestamp,
                                              transactions=[],
                                              miner_address=bob_xmss.address)
                         block.set_nonces(148, 0)
@@ -290,7 +297,8 @@ class TestChainManager(TestCase):
                     with mock.patch('qrl.core.misc.ntp.getTime') as time_mock:
                         time_mock.return_value = 1521889327 + devconfig.minimum_minting_delay * 3
                         block_2 = Block.create(block_number=2,
-                                               prevblock_headerhash=block.headerhash,
+                                               prev_block_headerhash=block.headerhash,
+                                               prev_block_timestamp=genesis_block.timestamp,
                                                transactions=[],
                                                miner_address=bob_xmss.address)
                         block_2.set_nonces(7, 0)

--- a/tests/core/test_Ephemeral.py
+++ b/tests/core/test_Ephemeral.py
@@ -76,9 +76,10 @@ class TestEphemeral(TestCase):
                                                                          xmss_pk=random_xmss1.pk)
                         lattice_public_key_txn._data.nonce = 1
                         lattice_public_key_txn.sign(random_xmss1)
-
+                        genesis_block = GenesisBlock()
                         tmp_block1 = Block.create(block_number=1,
-                                                  prevblock_headerhash=GenesisBlock().headerhash,
+                                                  prev_block_headerhash=genesis_block.headerhash,
+                                                  prev_block_timestamp=genesis_block.timestamp,
                                                   transactions=[lattice_public_key_txn],
                                                   miner_address=slave_xmss.address)
 
@@ -125,7 +126,8 @@ class TestEphemeral(TestCase):
                         # TODO (cyyber): Add Ephemeral Testing code using Naive RNG
 
                         tmp_block2 = Block.create(block_number=2,
-                                                  prevblock_headerhash=tmp_block1.headerhash,
+                                                  prev_block_headerhash=tmp_block1.headerhash,
+                                                  prev_block_timestamp=tmp_block1.timestamp,
                                                   transactions=[],
                                                   miner_address=slave_xmss.address)
 
@@ -140,7 +142,8 @@ class TestEphemeral(TestCase):
                         time_mock.return_value += config.dev.minimum_minting_delay * 2
 
                         tmp_block3 = Block.create(block_number=3,
-                                                  prevblock_headerhash=tmp_block2.headerhash,
+                                                  prev_block_headerhash=tmp_block2.headerhash,
+                                                  prev_block_timestamp=tmp_block1.timestamp,
                                                   transactions=[],
                                                   miner_address=slave_xmss.address)
 
@@ -154,7 +157,8 @@ class TestEphemeral(TestCase):
                         time_mock.return_value += config.dev.minimum_minting_delay
 
                         tmp_block4 = Block.create(block_number=4,
-                                                  prevblock_headerhash=tmp_block3.headerhash,
+                                                  prev_block_headerhash=tmp_block3.headerhash,
+                                                  prev_block_timestamp=tmp_block1.timestamp,
                                                   transactions=[],
                                                   miner_address=slave_xmss.address)
 

--- a/tests/core/test_State.py
+++ b/tests/core/test_State.py
@@ -27,7 +27,6 @@ def gen_blocks(block_count, state, miner_address):
         blocks = []
         with mock.patch('qrl.core.misc.ntp.getTime') as time_mock:
             time_mock.return_value = 1615270948
-            prev_hash = bytes(sha2_256(b'test'))
             addresses_state = dict()
             for i in range(0, block_count):
                 if i == 0:
@@ -38,7 +37,8 @@ def gen_blocks(block_count, state, miner_address):
                         addresses_state[bytes_addr]._data.balance = genesis_balance.balance
                 else:
                     block = Block.create(block_number=i,
-                                         prevblock_headerhash=prev_hash,
+                                         prev_block_headerhash=block.headerhash,
+                                         prev_block_timestamp=block.timestamp,
                                          transactions=[],
                                          miner_address=miner_address)
                     addresses_set = state.prepare_address_list(block)
@@ -61,7 +61,6 @@ def gen_blocks(block_count, state, miner_address):
                 state.put_block_number_mapping(block.block_number, bm, None)
                 state.update_mainchain_height(block.block_number, None)
                 state.put_addresses_state(addresses_state)
-                prev_hash = bytes(block.headerhash)
 
         return blocks
 
@@ -268,7 +267,8 @@ class TestState(TestCase):
             with State() as state:
                 batch = state.get_batch()
                 block = Block.create(block_number=10,
-                                     prevblock_headerhash=b'aa',
+                                     prev_block_headerhash=b'aa',
+                                     prev_block_timestamp=10,
                                      transactions=[],
                                      miner_address=b'aa')
                 state.put_block(block, batch)
@@ -389,7 +389,8 @@ class TestState(TestCase):
         with set_qrl_dir('no_data'):
             with State() as state:
                 block = Block.create(block_number=10,
-                                     prevblock_headerhash=b'',
+                                     prev_block_headerhash=b'',
+                                     prev_block_timestamp=10,
                                      transactions=[],
                                      miner_address=b'addr1')
                 # Test Case: without any transactions of block
@@ -398,7 +399,8 @@ class TestState(TestCase):
 
                 alice_xmss = get_alice_xmss()
                 block = Block.create(block_number=10,
-                                     prevblock_headerhash=b'',
+                                     prev_block_headerhash=b'',
+                                     prev_block_timestamp=10,
                                      transactions=[TransferTransaction.create(addrs_to=[b'addr2',
                                                                                         b'addr3'],
                                                                               amounts=[100, 100],
@@ -634,7 +636,8 @@ class TestState(TestCase):
                                                  xmss_pk=alice_xmss.pk)
 
                 block = Block.create(block_number=5,
-                                     prevblock_headerhash=b'',
+                                     prev_block_headerhash=b'',
+                                     prev_block_timestamp=10,
                                      transactions=[tx1],
                                      miner_address=b'')
 

--- a/tests/core/test_block.py
+++ b/tests/core/test_block.py
@@ -25,7 +25,8 @@ class TestBlock(TestCase):
     def test_verify_blob(self):
         alice_xmss = get_alice_xmss()
         block = Block.create(block_number=5,
-                             prevblock_headerhash=bytes(sha2_256(b'test')),
+                             prev_block_headerhash=bytes(sha2_256(b'test')),
+                             prev_block_timestamp=10,
                              transactions=[],
                              miner_address=alice_xmss.address)
         mining_blob = block.mining_blob
@@ -34,7 +35,8 @@ class TestBlock(TestCase):
     def test_mining_blob(self):
         alice_xmss = get_alice_xmss()
         block = Block.create(block_number=5,
-                             prevblock_headerhash=bytes(sha2_256(b'test')),
+                             prev_block_headerhash=bytes(sha2_256(b'test')),
+                             prev_block_timestamp=10,
                              transactions=[],
                              miner_address=alice_xmss.address)
 
@@ -54,7 +56,8 @@ class TestBlock(TestCase):
     def test_set_mining_nonce_from_blob(self):
         alice_xmss = get_alice_xmss()
         block = Block.create(block_number=5,
-                             prevblock_headerhash=bytes(sha2_256(b'test')),
+                             prev_block_headerhash=bytes(sha2_256(b'test')),
+                             prev_block_timestamp=10,
                              transactions=[],
                              miner_address=alice_xmss.address)
         current_mining_nonce = block.mining_nonce

--- a/tests/core/test_blockheader.py
+++ b/tests/core/test_blockheader.py
@@ -23,14 +23,16 @@ class TestBlockHeader(TestCase):
         self.assertIsNotNone(block_header)  # just to avoid warnings
 
     def test_init2(self):
-        block_header = BlockHeader.create(1, sha256(b'prev'), sha256(b'txs'), 10)
-        self.assertIsNotNone(block_header)  # just to avoid warnings
+        with mock.patch('qrl.core.misc.ntp.getTime') as time_mock:
+            time_mock.return_value = 1615270948
+            block_header = BlockHeader.create(1, sha256(b'prev'), time_mock.return_value, sha256(b'txs'), 10)
+            self.assertIsNotNone(block_header)  # just to avoid warnings
 
     def test_blob(self):
         with mock.patch('qrl.core.misc.ntp.getTime') as time_mock:
             time_mock.return_value = 1615270948
 
-            block_header = BlockHeader.create(1, sha256(b'prev'), sha256(b'txs'), 10)
+            block_header = BlockHeader.create(1, sha256(b'prev'), time_mock.return_value, sha256(b'txs'), 10)
             self.assertEquals('0074aa496ffe19107faaf418b720fb5b8446ba4b595c178fcf099c99b3dee99860d788c77910'
                               'a9000000000000000000000000ede0d022b37421b81b7bbcf5b497fb89408c05c7d713c5e1e5',
                               bin2hstr(block_header.mining_blob))
@@ -40,7 +42,7 @@ class TestBlockHeader(TestCase):
         with mock.patch('qrl.core.misc.ntp.getTime') as time_mock:
             time_mock.return_value = 1615270948
 
-            block_header = BlockHeader.create(1, sha256(b'prev'), sha256(b'txs'), 10)
+            block_header = BlockHeader.create(1, sha256(b'prev'), time_mock.return_value, sha256(b'txs'), 10)
             header_hash = block_header.generate_headerhash()
 
             self.assertEquals('eb2364355673f1d4384008dbc53a19050c6d1aaea01c724943c9a8f5d01fdece',
@@ -55,7 +57,7 @@ class TestBlockHeader(TestCase):
         with mock.patch('qrl.core.misc.ntp.getTime') as time_mock:
             time_mock.return_value = 1615270948
 
-            block_header = BlockHeader.create(1, sha256(b'prev'), sha256(b'txs'), 10)
+            block_header = BlockHeader.create(1, sha256(b'prev'), time_mock.return_value, sha256(b'txs'), 10)
 
             block_header.set_nonces(100, 0)
 

--- a/tests/services/test_PublicAPIService.py
+++ b/tests/services/test_PublicAPIService.py
@@ -258,7 +258,8 @@ class TestPublicAPI(TestCase):
         # Find a block
         db_state.get_block_by_number = MagicMock(
             return_value=Block.create(block_number=1,
-                                      prevblock_headerhash=sha256(b'reveal'),
+                                      prev_block_headerhash=sha256(b'reveal'),
+                                      prev_block_timestamp=10,
                                       transactions=[],
                                       miner_address=alice_xmss.address))
 
@@ -283,7 +284,8 @@ class TestPublicAPI(TestCase):
                                                       xmss_pk=alice_xmss.pk))
 
             blocks.append(Block.create(block_number=i,
-                                       prevblock_headerhash=sha256(b'reveal'),
+                                       prev_block_headerhash=sha256(b'reveal'),
+                                       prev_block_timestamp=10,
                                        transactions=txs,
                                        miner_address=alice_xmss.address))
 

--- a/tools/generate_genesis.py
+++ b/tools/generate_genesis.py
@@ -56,7 +56,8 @@ dist_xmss = XMSS.from_extended_seed(seed)
 transactions = get_migration_transactions(signing_xmss=dist_xmss)
 
 block = Block.create(block_number=0,
-                     prevblock_headerhash=config.dev.genesis_prev_headerhash,
+                     prev_block_headerhash=config.dev.genesis_prev_headerhash,
+                     prev_block_timestamp=config.dev.genesis_timestamp,
                      transactions=transactions,
                      miner_address=dist_xmss.address)
 


### PR DESCRIPTION
Create new Block with current NTP timestamp, if current NTP timestamp is less than the parent block timestamp, then set new block timestamp 1 second ahead of the parent block timestamp.