### PR TITLE
Create Block timestamp bug fix

### DIFF
--- a/src/qrl/core/Block.py
+++ b/src/qrl/core/Block.py
@@ -167,6 +167,8 @@ class Block(object):
             try:
                 parent_block = future_blocks[self.prev_headerhash]
             except KeyError:
+                logger.warning('Parent block not found')
+                logger.warning('Parent block headerhash %s', bin2hstr(self.prev_headerhash))
                 return False
 
         if not self.validate_parent_child_relation(parent_block):

--- a/src/qrl/core/BlockHeader.py
+++ b/src/qrl/core/BlockHeader.py
@@ -138,9 +138,9 @@ class BlockHeader(object):
 
         if bh._data.block_number != 0:
             bh._data.timestamp_seconds = int(ntp.getTime())
-            # If current block timestamp is less than the previous block timestamp
+            # If current block timestamp is less than or equals to the previous block timestamp
             # then set current block timestamp 1 sec higher than prev_block_timestamp
-            if bh._data.timestamp_seconds < prev_block_timestamp:
+            if bh._data.timestamp_seconds <= prev_block_timestamp:
                 bh._data.timestamp_seconds = prev_block_timestamp + 1
             if bh._data.timestamp_seconds == 0:
                 logger.warning('Failed to get NTP timestamp')

--- a/tests/core/test_State.py
+++ b/tests/core/test_State.py
@@ -461,7 +461,7 @@ class TestState(TestCase):
                 for i in range(1, 20):
                     datapoint = state.get_block_datapoint(blocks[i].headerhash)
                     self.assertEqual(datapoint.difficulty, "0")
-                    self.assertEqual(datapoint.timestamp, 1615270948)
+                    self.assertEqual(datapoint.timestamp, 1615270947 + i)
                     self.assertEqual(datapoint.header_hash, blocks[i].headerhash)
                     self.assertEqual(datapoint.header_hash_prev, blocks[i - 1].headerhash)
 

--- a/tests/core/test_blockheader.py
+++ b/tests/core/test_blockheader.py
@@ -33,8 +33,8 @@ class TestBlockHeader(TestCase):
             time_mock.return_value = 1615270948
 
             block_header = BlockHeader.create(1, sha256(b'prev'), time_mock.return_value, sha256(b'txs'), 10)
-            self.assertEquals('0074aa496ffe19107faaf418b720fb5b8446ba4b595c178fcf099c99b3dee99860d788c77910'
-                              'a9000000000000000000000000ede0d022b37421b81b7bbcf5b497fb89408c05c7d713c5e1e5',
+            self.assertEquals('00501846b24200c31fca7172a7f701ae50322579cfdf1d7777daab4ce6ead70b76debb2c51a1'
+                              'c70000000000000000000000002b80aecec05ad5c7c4f2259c8f69e2966a6ce102d4609af2cd',
                               bin2hstr(block_header.mining_blob))
             self.assertEquals(config.dev.mining_blob_size, len(block_header.mining_blob))
 
@@ -45,7 +45,7 @@ class TestBlockHeader(TestCase):
             block_header = BlockHeader.create(1, sha256(b'prev'), time_mock.return_value, sha256(b'txs'), 10)
             header_hash = block_header.generate_headerhash()
 
-            self.assertEquals('eb2364355673f1d4384008dbc53a19050c6d1aaea01c724943c9a8f5d01fdece',
+            self.assertEquals('81dd8032691331fb9cb6d4b8c3cf82dfec7873eb96789a10076b70da45315a38',
                               bin2hstr(header_hash))
 
             self.assertEquals(bin2hstr(header_hash),
@@ -63,7 +63,7 @@ class TestBlockHeader(TestCase):
 
             header_hash = block_header.generate_headerhash()
 
-            self.assertEquals('8ab90d398ef7d219fb985a15814525b42f597a44478599a4a25b4b0a10697cf2',
+            self.assertEquals('f48ef2a482b2b85b429979ea1d7014806754b3ff37705c4f61a54f17bca4ccc4',
                               bin2hstr(header_hash))
 
             self.assertEquals(bin2hstr(header_hash),


### PR DESCRIPTION
Missed equals to while comparing between block timestamp and parent timestamp, was resulting into child block timestamp equals to parent block timestamp.