### PR TITLE
Skip Block Message Receipt if parent block not found or block beyond limit

### DIFF
--- a/src/qrl/core/config.py
+++ b/src/qrl/core/config.py
@@ -173,7 +173,8 @@ class DevConfig(object):
         self.block_lead_timestamp = 30
         self.block_max_drift = 15
         self.max_future_blocks_length = 256
-        self.max_margin_block_number = 125
+        self.max_margin_block_number = 32
+        self.min_margin_block_number = 7
 
         self.public_ip = None
         self.reorg_limit = 7 * 24 * 60  # 7 days * 24 hours * 60 blocks per hour

--- a/src/qrl/core/p2p/p2pTxManagement.py
+++ b/src/qrl/core/p2p/p2pTxManagement.py
@@ -56,8 +56,12 @@ class P2PTxManagement(P2PBaseObserver):
             if mr_data.block_number > source.factory.chain_height + config.dev.max_margin_block_number:
                 logger.debug('Skipping block #%s as beyond lead limit', mr_data.block_number)
                 return
-            if mr_data.block_number < source.factory.chain_height - config.dev.reorg_limit:
-                logger.debug('Skipping block #%s as beyond re-org limit', mr_data.block_number)
+            if mr_data.block_number < source.factory.chain_height - config.dev.min_margin_block_number:
+                logger.debug('Skipping block #%s as beyond the limit', mr_data.block_number)
+                return
+
+            if not source.factory.is_block_present(mr_data.prev_headerhash):
+                logger.debug('Skipping block #%s as prev_headerhash not found', mr_data.block_number)
                 return
 
         if source.factory.master_mr.contains(msg_hash, mr_data.type):

--- a/src/qrl/core/p2p/p2pfactory.py
+++ b/src/qrl/core/p2p/p2pfactory.py
@@ -181,6 +181,13 @@ class P2PFactory(ServerFactory):
     def get_block(self, block_number):
         return self._chain_manager.get_block_by_number(block_number)
 
+    def is_block_present(self, header_hash: bytes) -> bool:
+        if not self._chain_manager.state.get_block(header_hash):
+            if header_hash not in self.pow.future_blocks:
+                return False
+
+        return True
+
     def block_received(self, source, block: Block):
         self.pow.last_pb_time = ntp.getTime()
         logger.info('>>> Received Block #%d %s', block.block_number, bin2hstr(block.headerhash))


### PR DESCRIPTION
Block's Message Receipt are now skipped if they are more than 32 blocks ahead from the current chain height or lagging behind by more than 7 blocks from current height.

It is also skipped if the no block is found for the prev_headerhash of the block.