### PR TITLE
Minor Optimization

### DIFF
--- a/src/qrl/core/processors/TxnProcessor.py
+++ b/src/qrl/core/processors/TxnProcessor.py
@@ -44,10 +44,14 @@ class TxnProcessor:
         is_valid_state = tx.validate_extended(addr_from_state=addr_from_state,
                                               addr_from_pk_state=addr_from_pk_state)
 
+        if not is_valid_state:
+            logger.info('>>>TX %s failed is_valid_state', bin2hstr(tx.txhash))
+            return False
+
         is_valid_pool_state = tx.validate_transaction_pool(self.transaction_pool_obj.transaction_pool)
 
-        if not (is_valid_state and is_valid_pool_state):
-            logger.info('>>>TX %s failed state_validate', bin2hstr(tx.txhash))
+        if not is_valid_pool_state:
+            logger.info('>>>TX %s failed is_valid_pool_state', bin2hstr(tx.txhash))
             return False
 
         logger.info('A TXN has been Processed %s', bin2hstr(tx.txhash))


### PR DESCRIPTION
While processing pending transactions, earlier we used to do state validation and transaction pool validation then finally check if both the validation passed. Now, just after the state validation is done, its being checked if state validation has passed, before making transaction pool validation.