### PR TITLE
Patch out NTP for test suite. Excludes doctests and (obviously) TestNTP.

### DIFF
--- a/src/qrl/core/BlockHeader.py
+++ b/src/qrl/core/BlockHeader.py
@@ -118,22 +118,6 @@ class BlockHeader(object):
                prev_block_timestamp: int,
                hashedtransactions: bytes,
                fee_reward: int):
-        """
-        Create a block header based on the parameters
-
-        >>> BlockHeader.create(blocknumber=1,
-        ...                    prev_block_headerhash=b'headerhash',
-        ...                    prev_block_timestamp=10,
-        ...                    hashedtransactions=b'some_data', fee_reward=1) is not None
-        True
-        >>> b=BlockHeader.create(blocknumber=1,
-        ...                      prev_block_headerhash=b'headerhash',
-        ...                      prev_block_timestamp=10,
-        ...                      hashedtransactions=b'some_data', fee_reward=1)
-        >>> b.epoch
-        0
-        """
-
         bh = BlockHeader()
         bh._data.block_number = blocknumber
 

--- a/tests/core/p2p/test_p2pprotocol.py
+++ b/tests/core/p2p/test_p2pprotocol.py
@@ -15,6 +15,8 @@ from qrl.core.qrlnode import QRLNode
 from qrl.generated import qrllegacy_pb2
 from pyqrllib.pyqrllib import hstr2bin, bin2hstr
 
+from tests.misc.helper import replacement_getTime
+
 logger.initialize_default()
 
 Host = namedtuple('Host', ['host', 'port'])
@@ -26,7 +28,8 @@ class TestP2PProtocol(TestCase):
         super(TestP2PProtocol, self).__init__(*args, **kwargs)
 
     def setUp(self):
-        self.channel = P2PProtocol()
+        with patch('qrl.core.misc.ntp.getTime', new=replacement_getTime):
+            self.channel = P2PProtocol()
 
         self.channel._observable = Mock()
 

--- a/tests/core/test_State.py
+++ b/tests/core/test_State.py
@@ -20,7 +20,9 @@ from qrl.core.TokenMetadata import TokenMetadata
 from qrl.core.Block import Block
 from qrl.core.BlockMetadata import BlockMetadata
 from qrl.generated import qrl_pb2
-from tests.misc.helper import set_qrl_dir, get_alice_xmss, get_bob_xmss, get_token_transaction, get_some_address
+
+from tests.misc.helper import set_qrl_dir, get_alice_xmss, get_bob_xmss, get_token_transaction, get_some_address, \
+    replacement_getTime
 
 logger.initialize_default()
 
@@ -69,6 +71,7 @@ def gen_blocks(block_count, state, miner_address):
     return blocks
 
 
+@mock.patch('qrl.core.misc.ntp.getTime', new=replacement_getTime)
 class TestState(TestCase):
     def __init__(self, *args, **kwargs):
         super(TestState, self).__init__(*args, **kwargs)
@@ -378,7 +381,7 @@ class TestState(TestCase):
                 tmp_json = state.get_block_metadata(b'block_headerhash2').to_json()
 
                 expected_json = b'{\n  "blockDifficulty": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",\n  ' \
-                                b'"cumulativeDifficulty": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="\n}' \
+                                b'"cumulativeDifficulty": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="\n}'
 
                 self.assertEqual(tmp_json, expected_json)
 

--- a/tests/core/test_TransactionPool.py
+++ b/tests/core/test_TransactionPool.py
@@ -22,6 +22,7 @@ def replacement_from_pbdata(protobuf_tx):
     return protobuf_tx
 
 
+@patch('qrl.core.misc.ntp.getTime', new=replacement_getTime)
 class TestTransactionPool(TestCase):
     """
     TransactionPool sits between incoming Transactions from the network and Blocks.
@@ -251,6 +252,7 @@ class TestTransactionPool(TestCase):
         self.assertEqual(m_broadcast_tx.call_count, 2)
 
 
+@patch('qrl.core.misc.ntp.getTime', new=replacement_getTime)
 class TestTransactionPoolRemoveTxInBlockFromPool(TestCase):
     """
     Up until 4096 (max_ots_tracking_index), the state of each OTS index USED/UNUSED is stored in a bitfield.
@@ -264,7 +266,9 @@ class TestTransactionPoolRemoveTxInBlockFromPool(TestCase):
     Of course, 4098 and 4099 also have to be deleted.
     """
 
+    @patch('qrl.core.misc.ntp.getTime', new=replacement_getTime)
     def setUp(self):
+
         self.txpool = TransactionPool(None)
 
         self.tx_3907 = make_tx(name='Mock TX 3907', txhash=b'h3907', ots_key=3907)

--- a/tests/core/test_block.py
+++ b/tests/core/test_block.py
@@ -2,7 +2,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 from unittest import TestCase
-
+from mock import patch
 from pyqrllib.pyqrllib import sha2_256
 
 from tests.misc.helper import get_alice_xmss
@@ -10,9 +10,12 @@ from qrl.core import config
 from qrl.core.misc import logger
 from qrl.core.Block import Block
 
+from tests.misc.helper import replacement_getTime
+
 logger.initialize_default()
 
 
+@patch('qrl.core.misc.ntp.getTime', new=replacement_getTime)
 class TestBlock(TestCase):
     def __init__(self, *args, **kwargs):
         super(TestBlock, self).__init__(*args, **kwargs)
@@ -20,7 +23,7 @@ class TestBlock(TestCase):
     def test_init(self):
         # TODO: Not much going on here..
         block = Block()
-        self.assertIsNotNone(block)             # just to avoid warnings
+        self.assertIsNotNone(block)  # just to avoid warnings
 
     def test_verify_blob(self):
         alice_xmss = get_alice_xmss()

--- a/tests/core/test_blockheader.py
+++ b/tests/core/test_blockheader.py
@@ -14,59 +14,58 @@ from qrl.crypto.misc import sha256
 logger.initialize_default()
 
 
+@mock.patch('qrl.core.misc.ntp.getTime', return_value=1615270948)
 class TestBlockHeader(TestCase):
     def __init__(self, *args, **kwargs):
         super(TestBlockHeader, self).__init__(*args, **kwargs)
 
-    def test_init(self):
+    def test_create(self, time_mock):
+        b = BlockHeader.create(blocknumber=1, prev_block_headerhash=b'headerhash', prev_block_timestamp=10,
+                               hashedtransactions=b'some_data', fee_reward=1)
+        self.assertIsNotNone(b)
+
+        b = BlockHeader.create(blocknumber=1, prev_block_headerhash=b'headerhash', prev_block_timestamp=10,
+                               hashedtransactions=b'some_data', fee_reward=1)
+        self.assertEqual(b.epoch, 0)
+
+    def test_init(self, time_mock):
         block_header = BlockHeader()
         self.assertIsNotNone(block_header)  # just to avoid warnings
 
-    def test_init2(self):
-        with mock.patch('qrl.core.misc.ntp.getTime') as time_mock:
-            time_mock.return_value = 1615270948
-            block_header = BlockHeader.create(1, sha256(b'prev'), time_mock.return_value, sha256(b'txs'), 10)
-            self.assertIsNotNone(block_header)  # just to avoid warnings
+    def test_init2(self, time_mock):
+        block_header = BlockHeader.create(1, sha256(b'prev'), time_mock.return_value, sha256(b'txs'), 10)
+        self.assertIsNotNone(block_header)  # just to avoid warnings
 
-    def test_blob(self):
-        with mock.patch('qrl.core.misc.ntp.getTime') as time_mock:
-            time_mock.return_value = 1615270948
+    def test_blob(self, time_mock):
+        block_header = BlockHeader.create(1, sha256(b'prev'), time_mock.return_value, sha256(b'txs'), 10)
+        self.assertEquals('00501846b24200c31fca7172a7f701ae50322579cfdf1d7777daab4ce6ead70b76debb2c51a1'
+                          'c700000000000000000000000000000000002b80aecec05ad5c7c4f2259c8f69e2966a6ce102',
+                          bin2hstr(block_header.mining_blob))
+        self.assertEquals(config.dev.mining_blob_size, len(block_header.mining_blob))
 
-            block_header = BlockHeader.create(1, sha256(b'prev'), time_mock.return_value, sha256(b'txs'), 10)
-            self.assertEquals('00501846b24200c31fca7172a7f701ae50322579cfdf1d7777daab4ce6ead70b76debb2c51a1'
-                              'c700000000000000000000000000000000002b80aecec05ad5c7c4f2259c8f69e2966a6ce102',
-                              bin2hstr(block_header.mining_blob))
-            self.assertEquals(config.dev.mining_blob_size, len(block_header.mining_blob))
+    def test_hash(self, time_mock):
+        block_header = BlockHeader.create(1, sha256(b'prev'), time_mock.return_value, sha256(b'txs'), 10)
+        header_hash = block_header.generate_headerhash()
 
-    def test_hash(self):
-        with mock.patch('qrl.core.misc.ntp.getTime') as time_mock:
-            time_mock.return_value = 1615270948
+        self.assertEquals('ac021e63df860ea930ea9de05e350d3f74af35341688134f92957f1dac3a62fb',
+                          bin2hstr(header_hash))
 
-            block_header = BlockHeader.create(1, sha256(b'prev'), time_mock.return_value, sha256(b'txs'), 10)
-            header_hash = block_header.generate_headerhash()
+        self.assertEquals(bin2hstr(header_hash),
+                          bin2hstr(block_header.headerhash))
 
-            self.assertEquals('ac021e63df860ea930ea9de05e350d3f74af35341688134f92957f1dac3a62fb',
-                              bin2hstr(header_hash))
+        self.assertEquals(32, len(block_header.headerhash))
 
-            self.assertEquals(bin2hstr(header_hash),
-                              bin2hstr(block_header.headerhash))
+    def test_hash_nonce(self, time_mock):
+        block_header = BlockHeader.create(1, sha256(b'prev'), time_mock.return_value, sha256(b'txs'), 10)
 
-            self.assertEquals(32, len(block_header.headerhash))
+        block_header.set_nonces(100, 0)
 
-    def test_hash_nonce(self):
-        with mock.patch('qrl.core.misc.ntp.getTime') as time_mock:
-            time_mock.return_value = 1615270948
+        header_hash = block_header.generate_headerhash()
 
-            block_header = BlockHeader.create(1, sha256(b'prev'), time_mock.return_value, sha256(b'txs'), 10)
+        self.assertEquals('b6f937020f9876f3c6887e7a6759201411ed8826ed9ce4283ffe48e1aa90d692',
+                          bin2hstr(header_hash))
 
-            block_header.set_nonces(100, 0)
+        self.assertEquals(bin2hstr(header_hash),
+                          bin2hstr(block_header.headerhash))
 
-            header_hash = block_header.generate_headerhash()
-
-            self.assertEquals('b6f937020f9876f3c6887e7a6759201411ed8826ed9ce4283ffe48e1aa90d692',
-                              bin2hstr(header_hash))
-
-            self.assertEquals(bin2hstr(header_hash),
-                              bin2hstr(block_header.headerhash))
-
-            self.assertEquals(32, len(block_header.headerhash))
+        self.assertEquals(32, len(block_header.headerhash))

--- a/tests/core/test_node.py
+++ b/tests/core/test_node.py
@@ -3,8 +3,8 @@
 # file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 import contextlib
 from unittest import TestCase
+from mock import Mock, MagicMock, patch
 
-from mock import Mock, MagicMock
 from pyqryptonight.pyqryptonight import StringToUInt256
 
 from tests.misc.helper import get_alice_xmss, get_random_xmss
@@ -14,6 +14,8 @@ from qrl.core.AddressState import AddressState
 from qrl.core.ESyncState import ESyncState
 from qrl.core.GenesisBlock import GenesisBlock
 from qrl.core.node import POW
+
+from tests.misc.helper import replacement_getTime
 
 logger.initialize_default()
 
@@ -28,6 +30,7 @@ def set_mining_enabled(new_value):
         config.user.mining_enabled = old_value
 
 
+@patch('qrl.core.misc.ntp.getTime', new=replacement_getTime)
 class TestNode(TestCase):
     def __init__(self, *args, **kwargs):
         super(TestNode, self).__init__(*args, **kwargs)

--- a/tests/core/test_qrlnode.py
+++ b/tests/core/test_qrlnode.py
@@ -1,0 +1,11 @@
+from unittest import TestCase
+from mock import patch
+
+from tests.misc.helper import get_alice_xmss, replacement_getTime
+
+alice = get_alice_xmss()
+
+
+@patch('qrl.core.misc.ntp.getTime', new=replacement_getTime)
+class TestQRLNodeReal(TestCase):
+    pass

--- a/tests/services/test_BaseService.py
+++ b/tests/services/test_BaseService.py
@@ -4,7 +4,7 @@
 from unittest import TestCase
 
 import os
-from mock import Mock
+from mock import Mock, patch
 
 from qrl.core import config
 from qrl.core.misc import logger
@@ -12,10 +12,12 @@ from qrl.core.State import State
 from qrl.core.qrlnode import QRLNode
 from qrl.generated.qrlbase_pb2 import GetNodeInfoReq
 from qrl.services.BaseService import BaseService
+from tests.misc.helper import replacement_getTime
 
 logger.initialize_default()
 
 
+@patch('qrl.core.misc.ntp.getTime', new=replacement_getTime)
 class TestBaseAPI(TestCase):
     def __init__(self, *args, **kwargs):
         super(TestBaseAPI, self).__init__(*args, **kwargs)

--- a/tests/services/test_MiningAPIService.py
+++ b/tests/services/test_MiningAPIService.py
@@ -3,7 +3,7 @@
 # file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 from unittest import TestCase
 
-from mock import Mock, MagicMock
+from mock import Mock, MagicMock, patch
 
 from qrl.core.Block import Block
 from qrl.core.BlockHeader import BlockHeader
@@ -17,10 +17,12 @@ from qrl.core.qrlnode import QRLNode
 from qrl.crypto.misc import sha256
 from qrl.generated import qrlmining_pb2
 from qrl.services.MiningAPIService import MiningAPIService
+from tests.misc.helper import replacement_getTime
 
 logger.initialize_default()
 
 
+@patch('qrl.core.misc.ntp.getTime', new=replacement_getTime)
 class TestMiningAPI(TestCase):
     def __init__(self, *args, **kwargs):
         super(TestMiningAPI, self).__init__(*args, **kwargs)

--- a/tests/services/test_PublicAPIService.py
+++ b/tests/services/test_PublicAPIService.py
@@ -5,7 +5,7 @@ import heapq
 from unittest import TestCase
 
 from grpc import ServicerContext, StatusCode
-from mock import Mock, MagicMock
+from mock import Mock, MagicMock, patch
 from pyqrllib.pyqrllib import str2bin, hstr2bin, bin2hstr
 
 from qrl.core import config
@@ -23,11 +23,12 @@ from qrl.core.qrlnode import QRLNode
 from qrl.crypto.misc import sha256
 from qrl.generated import qrl_pb2
 from qrl.services.PublicAPIService import PublicAPIService
-from tests.misc.helper import get_alice_xmss, get_bob_xmss
+from tests.misc.helper import get_alice_xmss, get_bob_xmss, replacement_getTime
 
 logger.initialize_default()
 
 
+@patch('qrl.core.misc.ntp.getTime', new=replacement_getTime)
 class TestPublicAPI(TestCase):
     def __init__(self, *args, **kwargs):
         super(TestPublicAPI, self).__init__(*args, **kwargs)

--- a/tests/services/test_PublicAPIService_transfer.py
+++ b/tests/services/test_PublicAPIService_transfer.py
@@ -4,7 +4,7 @@
 from unittest import TestCase
 
 from grpc import ServicerContext
-from mock import Mock
+from mock import Mock, patch
 from pyqrllib.pyqrllib import bin2hstr, QRLHelper
 
 from qrl.core.ChainManager import ChainManager
@@ -17,11 +17,12 @@ from qrl.core.qrlnode import QRLNode
 from qrl.crypto.misc import sha256
 from qrl.generated import qrl_pb2
 from qrl.services.PublicAPIService import PublicAPIService
-from tests.misc.helper import get_alice_xmss, get_bob_xmss, set_default_balance_size, set_qrl_dir
+from tests.misc.helper import get_alice_xmss, get_bob_xmss, set_default_balance_size, set_qrl_dir, replacement_getTime
 
 logger.initialize_default()
 
 
+@patch('qrl.core.misc.ntp.getTime', new=replacement_getTime)
 class TestPublicAPI(TestCase):
     def __init__(self, *args, **kwargs):
         super(TestPublicAPI, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Since patch does not go into TestCase.setUp(), @patch decorators were added there additionally.
Blockheader.create() doctest moved to unittest (so that I can patch NTP out)

Making a PR now because each time I rebase my working branch, this commit always gives me problems.