### PR TITLE
Wallet Daemon Optimization & More checks

### DIFF
--- a/src/qrl/core/Wallet.py
+++ b/src/qrl/core/Wallet.py
@@ -96,6 +96,12 @@ class Wallet:
 
         return xmss
 
+    def is_encrypted(self) -> bool:
+        if len(self.address_items) == 0:
+            return False
+
+        return self.address_items[0].encrypted
+
     def wallet_info(self):
         """
         Provides Wallet Info
@@ -280,7 +286,7 @@ class Wallet:
         tmp['encrypted'] = True
         self._address_items[index] = AddressItem(**tmp)
 
-    def decrypt(self, password: str):
+    def decrypt(self, password: str, first_address_only: bool=False):
         if self.encrypted_partially:
             raise WalletEncryptionError("Some addresses are already decrypted. Please re-encrypt all addresses before"
                                         "running decrypt().")
@@ -297,6 +303,8 @@ class Wallet:
         try:
             for i in range(len(self._address_items)):
                 decryptor(i, password)
+                if first_address_only:
+                    return
         except Exception as e:
             raise WalletDecryptionError("Error during decryption. Likely due to invalid password: {}".format(str(e)))
 

--- a/src/qrl/daemon/walletd.py
+++ b/src/qrl/daemon/walletd.py
@@ -282,6 +282,12 @@ class WalletD:
         self.load_wallet()
 
     def change_passphrase(self, old_passphrase: str, new_passphrase: str):
+        if len(old_passphrase) == 0:
+            raise Exception('Missing Old Passphrase')
+
+        if len(new_passphrase) == 0:
+            raise Exception('Missing New Passphrase')
+
         if old_passphrase == new_passphrase:
             raise Exception('Old Passphrase and New Passphrase cannot be same')
 

--- a/src/qrl/daemon/walletd.py
+++ b/src/qrl/daemon/walletd.py
@@ -56,7 +56,7 @@ class WalletD:
 
     def authenticate(self):
         if not self._passphrase:
-            if self._wallet.encrypted:
+            if self._wallet.is_encrypted():
                 raise ValueError('Failed: Passphrase Missing')
 
     def _encrypt_last_item(self):
@@ -264,7 +264,7 @@ class WalletD:
         return tx.pbdata
 
     def encrypt_wallet(self, passphrase: str):
-        if self._wallet.encrypted:
+        if self._wallet.is_encrypted():
             raise Exception('Wallet Already Encrypted')
         if not passphrase:
             raise Exception("Missing Passphrase")
@@ -278,7 +278,7 @@ class WalletD:
 
     def unlock_wallet(self, passphrase: str):
         self._passphrase = passphrase
-        self._wallet.decrypt(passphrase)
+        self._wallet.decrypt(passphrase, first_address_only=True)
         self.load_wallet()
 
     def change_passphrase(self, old_passphrase: str, new_passphrase: str):


### PR DESCRIPTION
Instead of decrypting all addresses in a wallet to validate the passphrase, we now decrypt only first address in the wallet. Otherwise, anyone having 1000 of addresses in a wallet, will consume a lot of time, just to unlock the wallet.

Checks for old_passphrase and new_passphrase missing has been added for Change Passphrase.