### PR TITLE
Added state validation for stale transaction + Unit Test

### DIFF
--- a/src/qrl/core/ChainManager.py
+++ b/src/qrl/core/ChainManager.py
@@ -316,7 +316,7 @@ class ChainManager:
                 return self._fork_recovery(block, fork_state), True
 
             self._update_chainstate(block, batch)
-            self.tx_pool.check_stale_txn(block.block_number)
+            self.tx_pool.check_stale_txn(self._state, block.block_number)
             self.trigger_miner = True
 
         return True, False

--- a/src/qrl/core/TransactionInfo.py
+++ b/src/qrl/core/TransactionInfo.py
@@ -47,3 +47,22 @@ class TransactionInfo:
 
     def update_block_number(self, current_block_number: int):
         self._block_number = current_block_number
+
+    def validate(self, state) -> bool:
+        addresses_set = set()
+        self.transaction.set_affected_address(addresses_set)
+
+        addresses_state = dict()
+        for address in addresses_set:
+            addresses_state[address] = state.get_address_state(address)
+
+        addr_from_pk_state = addresses_state[self.transaction.addr_from]
+        addr_from_pk = Transaction.get_slave(self.transaction)
+
+        if addr_from_pk:
+            addr_from_pk_state = addresses_state[addr_from_pk]
+
+        if not self.transaction.validate_extended(addresses_state[self.transaction.addr_from], addr_from_pk_state):
+            return False
+
+        return True

--- a/src/qrl/core/TransactionPool.py
+++ b/src/qrl/core/TransactionPool.py
@@ -133,12 +133,16 @@ class TransactionPool:
                 logger.warning('Block #%s %s', block.block_number, bin2hstr(block.headerhash))
                 return
 
-    def check_stale_txn(self, current_block_number):
+    def check_stale_txn(self, state, current_block_number):
         i = 0
         while i < len(self.transaction_pool):
             tx_info = self.transaction_pool[i][1]
             if tx_info.is_stale(current_block_number):
+                if not tx_info.validate(state):
+                    logger.warning('Txn validation failed for tx in tx_pool')
+                    self.remove_tx_from_pool(tx_info.transaction)
+                    continue
+
                 tx_info.update_block_number(current_block_number)
                 self.broadcast_tx(tx_info.transaction)
-                continue
             i += 1

--- a/tests/misc/MockHelper/mock_function.py
+++ b/tests/misc/MockHelper/mock_function.py
@@ -1,0 +1,21 @@
+# coding=utf-8
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+
+
+class MockFunction:
+    def __init__(self, default=None):
+        self.data = dict()
+        self.default = default
+
+    def put(self, key, value):
+        self.data[key] = value
+
+    def get(self, key):
+        if key in self.data:
+            return self.data[key]
+
+        return self.default
+
+    def remove(self, key):
+        del self.data[key]


### PR DESCRIPTION
All stale transaction goes through state validation. If stale transaction pass state validation, it is broadcasted otherwise it is dropped.