### PR TITLE
Updated some logging messages to use bin2hstr() for easier-to-read logs

### DIFF
--- a/src/qrl/core/txs/CoinBase.py
+++ b/src/qrl/core/txs/CoinBase.py
@@ -68,11 +68,11 @@ class CoinBase(Transaction):
     def validate_extended(self, block_number: int):
         if self.master_addr != config.dev.coinbase_address:
             logger.warning('Master address doesnt match with coinbase_address')
-            logger.warning('%s %s', bin2hstr(self.master_addr), config.dev.coinbase_address)
+            logger.warning('%s %s', bin2hstr(self.master_addr), bin2hstr(config.dev.coinbase_address))
             return False
 
         if not AddressState.address_is_valid(self.addr_to):
-            logger.warning('Invalid address addr_from: %s addr_to: %s', self.master_addr, self.addr_to)
+            logger.warning('Invalid address addr_from: %s addr_to: %s', bin2hstr(self.master_addr), bin2hstr(self.addr_to))
             return False
 
         if self.nonce != block_number + 1:

--- a/src/qrl/core/txs/TokenTransaction.py
+++ b/src/qrl/core/txs/TokenTransaction.py
@@ -132,16 +132,16 @@ class TokenTransaction(Transaction):
         tx_balance = addr_from_state.balance
 
         if not AddressState.address_is_valid(self.addr_from):
-            logger.warning('Invalid address addr_from: %s', self.addr_from)
+            logger.warning('Invalid address addr_from: %s', bin2hstr(self.addr_from))
             return False
 
         if not AddressState.address_is_valid(self.owner):
-            logger.warning('Invalid address owner_addr: %s', self.owner)
+            logger.warning('Invalid address owner_addr: %s', bin2hstr(self.owner))
             return False
 
         for address_balance in self.initial_balances:
             if not AddressState.address_is_valid(address_balance.address):
-                logger.warning('Invalid address address in initial_balances: %s', address_balance.address)
+                logger.warning('Invalid address in initial_balances: %s', bin2hstr(address_balance.address))
                 return False
 
         if tx_balance < self.fee:

--- a/src/qrl/core/txs/Transaction.py
+++ b/src/qrl/core/txs/Transaction.py
@@ -264,7 +264,7 @@ class Transaction(object, metaclass=ABCMeta):
         if verify_signature and self.txhash != expected_transaction_hash:
             logger.warning('Invalid Transaction hash')
             logger.warning('Expected Transaction hash %s', bin2hstr(expected_transaction_hash))
-            logger.warning('Found Transaction hash %s', expected_transaction_hash)
+            logger.warning('Found Transaction hash %s', bin2hstr(self.txhash))
             raise ValueError("Invalid Transaction Hash")
 
         if verify_signature and not XmssFast.verify(self.get_data_hash(),

--- a/src/qrl/core/txs/TransferTokenTransaction.py
+++ b/src/qrl/core/txs/TransferTokenTransaction.py
@@ -98,12 +98,12 @@ class TransferTokenTransaction(Transaction):
             return False
 
         if not AddressState.address_is_valid(self.addr_from):
-            logger.warning('[TransferTokenTransaction] Invalid address addr_from: %s', self.addr_from)
+            logger.warning('[TransferTokenTransaction] Invalid address addr_from: %s', bin2hstr(self.addr_from))
             return False
 
         for addr_to in self.addrs_to:
             if not AddressState.address_is_valid(addr_to):
-                logger.warning('[TransferTokenTransaction] Invalid address addr_to: %s', addr_to)
+                logger.warning('[TransferTokenTransaction] Invalid address addr_to: %s', bin2hstr(addr_to))
                 return False
 
         return True
@@ -127,7 +127,7 @@ class TransferTokenTransaction(Transaction):
             return False
 
         if not addr_from_state.is_token_exists(self.token_txhash):
-            logger.info('%s doesnt own any such token %s ', self.addr_from, bin2hstr(self.token_txhash))
+            logger.info('%s doesnt own any such token %s ', bin2hstr(self.addr_from), bin2hstr(self.token_txhash))
             return False
 
         token_balance = addr_from_state.get_token_balance(self.token_txhash)

--- a/src/qrl/core/txs/TransferTransaction.py
+++ b/src/qrl/core/txs/TransferTransaction.py
@@ -85,12 +85,12 @@ class TransferTransaction(Transaction):
             return False
 
         if not AddressState.address_is_valid(self.addr_from):
-            logger.warning('[TransferTransaction] Invalid address addr_from: %s', self.addr_from)
+            logger.warning('[TransferTransaction] Invalid address addr_from: %s', bin2hstr(self.addr_from))
             return False
 
         for addr_to in self.addrs_to:
             if not AddressState.address_is_valid(addr_to):
-                logger.warning('[TransferTransaction] Invalid address addr_to: %s', addr_to)
+                logger.warning('[TransferTransaction] Invalid address addr_to: %s', bin2hstr(addr_to))
                 return False
 
         return True

--- a/src/qrl/services/PublicAPIService.py
+++ b/src/qrl/services/PublicAPIService.py
@@ -126,6 +126,7 @@ class PublicAPIService(PublicAPIServicer):
                 answer.error_code = qrl_pb2.PushTransactionResp.SUBMITTED
                 answer.tx_hash = tx.txhash
             else:
+                answer.error_description = 'Signature too short'
                 answer.error_code = qrl_pb2.PushTransactionResp.VALIDATION_FAILED
 
         except Exception as e:


### PR DESCRIPTION
Strictly changing logging or error messages in this PR.  I was doing some testing and encountered some difficult to read addresses.  I tried to apply bin2hstr() to all log messages in the various transactions where I thought it was helpful.  I also added an error description to PushTransaction if the signature is too short.