### PR TITLE
Optimization: Disallow incoming transaction and stale check while syncing to mainchain

### DIFF
--- a/src/qrl/core/p2p/p2pTxManagement.py
+++ b/src/qrl/core/p2p/p2pTxManagement.py
@@ -4,7 +4,7 @@ from qrl.core import config
 from qrl.core.ESyncState import ESyncState
 from qrl.core.txs.Transaction import Transaction
 from qrl.core.messagereceipt import MessageReceipt
-from qrl.core.misc import logger
+from qrl.core.misc import logger, ntp
 from qrl.core.p2p.p2pObserver import P2PBaseObserver
 from qrl.generated import qrllegacy_pb2
 
@@ -46,6 +46,9 @@ class P2PTxManagement(P2PBaseObserver):
             return
 
         if mr_data.type == qrllegacy_pb2.LegacyMessage.TX:
+            if ntp.getTime() < source.factory.pow.suspend_mining_timestamp:
+                return
+
             if source.factory._chain_manager.tx_pool.is_full_pending_transaction_pool():
                 logger.warning('TX pool size full, incoming tx dropped. mr hash: %s', bin2hstr(msg_hash))
                 return

--- a/src/qrl/core/p2p/p2pfactory.py
+++ b/src/qrl/core/p2p/p2pfactory.py
@@ -214,7 +214,7 @@ class P2PFactory(ServerFactory):
             logger.warning('Syncing Failed: Block Validation Failed')
             return
 
-        if self._chain_manager.add_block(block):
+        if self._chain_manager.add_block(block, check_stale=False):
             if self._chain_manager.last_block.headerhash == block.headerhash:
                 self.pow.suspend_mining_timestamp = ntp.getTime() + config.dev.sync_delay_mining
         else:

--- a/tests/core/p2p/test_p2pTxManagement.py
+++ b/tests/core/p2p/test_p2pTxManagement.py
@@ -118,6 +118,8 @@ class TestP2PTxManagementHandlers(TestCase):
     def setUp(self):
         self.channel = Mock(autospec=P2PProtocol)
         self.channel.factory = Mock(autospec=P2PFactory)
+        self.channel.factory.pow = Mock()
+        self.channel.factory.pow.suspend_mining_timestamp = 0
         self.channel.factory.master_mr = Mock(autospec=MessageReceipt)
 
     def tearDown(self):


### PR DESCRIPTION
For the unsynced nodes, stale check was triggered, due to which all the transactions which has been collected while syncing, were considered as stale and rebroadcasted, resulting into spamming of transactions. So stale check has been disabled for nodes syncing to mainchain .

Nodes syncing to mainchain, will not receive any transactions.