### PR TITLE
Fix for version request message being filtered before send

### DIFF
--- a/src/qrl/core/p2p/p2pprotocol.py
+++ b/src/qrl/core/p2p/p2pprotocol.py
@@ -271,7 +271,8 @@ class P2PProtocol(Protocol):
     ###################################################
 
     def send_version_request(self):
-        msg = qrllegacy_pb2.LegacyMessage(func_name=qrllegacy_pb2.LegacyMessage.VE)
+        msg = qrllegacy_pb2.LegacyMessage(func_name=qrllegacy_pb2.LegacyMessage.VE,
+                                          veData=qrllegacy_pb2.VEData())
         self.send(msg)
 
     def send_peer_list(self):

--- a/tests/core/p2p/test_p2pprotocol.py
+++ b/tests/core/p2p/test_p2pprotocol.py
@@ -123,6 +123,13 @@ class TestP2PProtocol(TestCase):
         self.channel.peer_manager.ban_channel.assert_called_with(self.channel)
 
     @patch('qrl.core.misc.ntp.getTime')
+    def test_send_version_request(self, getTime):
+        getTime.return_value = 1525078652.9991353
+        version_request = b'\x00\x00\x00\x02\x1a\x00'
+        self.channel.send_version_request()
+        self.channel.transport.write.assert_called_with(version_request)
+
+    @patch('qrl.core.misc.ntp.getTime')
     def test_send_sync(self, getTime):
         getTime.return_value = 1525078652.9991353
         self.channel.send_sync(synced=True)


### PR DESCRIPTION
Running a test-net node I noticed main-net block numbers being received from peers.  I could not find log statements recording any peer's genesis prev_headerhash values.  Continued investigation in P2PProtocol led to discovering the empty version request message was being filtered out in  _wrap_message() just before sending.  Without a version request, the node would not receive populated version messages responses from peers and therefore could not drop mismatching nodes.  The fix is to provide an empty veData field in the message which makes the message length greater than zero and therefore not filtered.