### PR TITLE
GetTransaction now also checks for tx in pending_tx_pool

### DIFF
--- a/src/qrl/core/ChainManager.py
+++ b/src/qrl/core/ChainManager.py
@@ -100,6 +100,12 @@ class ChainManager:
                 tx = tx_set[1].transaction
                 if tx.txhash == transaction_hash:
                     return [tx, tx_set[1].timestamp]
+            if transaction_hash in self.tx_pool.pending_tx_pool_hash:
+                for tx_set in self.tx_pool.pending_tx_pool:
+                    tx = tx_set[1].transaction
+                    if tx.txhash == transaction_hash:
+                        return [tx, tx_set[1].timestamp]
+
             return []
 
     def get_block_metadata(self, header_hash: bytes) -> Optional[BlockMetadata]:


### PR DESCRIPTION
This change has been done, as the exchanges needs to verify if the transaction submitted to the node is still in the mempool.