### PR TITLE
Fix: Block deserialized by the content of BlockNumberMapping resulting into a blank Block

### DIFF
--- a/src/qrl/services/PublicAPIService.py
+++ b/src/qrl/services/PublicAPIService.py
@@ -256,7 +256,8 @@ class PublicAPIService(PublicAPIServicer):
         # NOTE: This is temporary, indexes are accepted for blocks
         try:
             block = self.qrlnode.get_block_from_hash(query)
-            if block is None:
+            # The condition after or is to avoid a bug, where a block is deserialized by BlockNumberMapping
+            if block is None or (block.block_number == 0 and block.prev_headerhash != config.user.genesis_prev_headerhash):
                 query_str = query.decode()
                 query_index = int(query_str)
                 block = self.qrlnode.get_block_from_index(query_index)


### PR DESCRIPTION
It was expected while deserializing Block by the content of any other protobuf message, will result into error. Recently, it has been noticed that its not the case, and there is a possibility where a Block can be deserialized by the content of BlockNumberMapping or any other protobuf message. This is responsible for API not returning correct data for the blocknumber 722905.

This fix will avoid any blank block returned and API will further query for the block by the blocknumber.