### PR TITLE
Updated p2p protocol

### DIFF
--- a/src/qrl/core/p2p/p2pprotocol.py
+++ b/src/qrl/core/p2p/p2pprotocol.py
@@ -39,6 +39,8 @@ class P2PProtocol(Protocol):
         self._connected_at = ntp.getTime()
         self._valid_message_count = 0
 
+        self._public_port = 0
+
     @property
     def peer(self):
         return IPMetadata(self.transport.getPeer().host, self.transport.getPeer().port)
@@ -46,6 +48,14 @@ class P2PProtocol(Protocol):
     @property
     def host(self):
         return IPMetadata(self.transport.getHost().host, self.transport.getHost().port)
+
+    @property
+    def public_port(self):
+        return self._public_port
+
+    @property
+    def ip_public_port(self):
+        return "{}:{}".format(self.transport.getHost().host, self._public_port)
 
     @property
     def connected_at(self):
@@ -73,6 +83,9 @@ class P2PProtocol(Protocol):
     def tx_manager(self):
         # FIXME: this is breaking encapsulation
         return self.factory._qrl_node.tx_manager
+
+    def set_public_port(self, public_port):
+        self._public_port = public_port
 
     def register(self, message_type, func: Callable):
         self._observable.register(message_type, func)

--- a/src/qrl/core/p2p/p2pprotocol.py
+++ b/src/qrl/core/p2p/p2pprotocol.py
@@ -55,7 +55,7 @@ class P2PProtocol(Protocol):
 
     @property
     def ip_public_port(self):
-        return "{}:{}".format(self.transport.getHost().host, self._public_port)
+        return "{}:{}".format(self.transport.getPeer().host, self._public_port)
 
     @property
     def connected_at(self):

--- a/src/qrl/core/qrlnode.py
+++ b/src/qrl/core/qrlnode.py
@@ -41,7 +41,6 @@ class QRLNode:
 
         self.peer_manager = P2PPeerManager()
         self.peer_manager.load_peer_addresses()
-        self.peer_manager.register(P2PPeerManager.EventType.NO_PEERS, self.connect_peers)
 
         self.p2pchain_manager = P2PChainManager()
 
@@ -152,9 +151,6 @@ class QRLNode:
     def get_peers_stat(self) -> list:
         return self.peer_manager.get_peers_stat()
 
-    def connect_peers(self):
-        self.peer_manager.connect_peers()
-
     ####################################################
     ####################################################
     ####################################################
@@ -203,7 +199,7 @@ class QRLNode:
                                       sync_state=self.sync_state,
                                       qrl_node=self)  # FIXME: Try to avoid cyclic references
 
-        self.peer_manager._p2pfactory = self._p2pfactory
+        self.peer_manager.set_p2p_factory(self._p2pfactory)
         self._p2pfactory.start_listening()
 
     ####################################################

--- a/src/qrl/main.py
+++ b/src/qrl/main.py
@@ -129,7 +129,6 @@ def main():
     admin_service, grpc_service, mining_service, debug_service = start_services(qrlnode)
 
     qrlnode.start_listening()
-    qrlnode.connect_peers()
 
     qrlnode.start_pow(args.mining_thread_count)
 

--- a/tests/core/p2p/test_p2pPeerManager.py
+++ b/tests/core/p2p/test_p2pPeerManager.py
@@ -151,13 +151,13 @@ class TestP2PPeerManager(TestCase):
         """
         extend_known_peers() not only writes out, it automatically connects to any new peers.
         """
-        self.peer_manager._p2pfactory = Mock()
+        self.peer_manager._p2p_factory = Mock()
         self.peer_manager._known_peers = {'1.1.1.1:9000'}
         with set_qrl_dir('no_data') as tempdir:
             self.peer_manager.peers_path = os.path.join(tempdir, config.dev.peers_filename)
             self.peer_manager.extend_known_peers({'2.2.2.2:9000'})
 
-        self.peer_manager._p2pfactory.connect_peer.assert_called_once_with('2.2.2.2:9000')
+        self.peer_manager._p2p_factory.connect_peer.assert_called_once_with({'2.2.2.2:9000'})
 
     def test_remove_channel(self):
         """
@@ -286,11 +286,10 @@ class TestP2PPeerManager(TestCase):
         channel = make_channel()
         channel.host = IPMetadata('187.0.0.1', 9000)
         channel.peer = IPMetadata('187.0.0.2', 9000)
+        channel.ip_public_port = '187.0.0.1:9000'
 
         # handle_peer_list() will call extend_known_peers(), so we gotta mock it out. It's tested elsewhere anyway.
-        self.peer_manager.extend_known_peers = Mock(autospec=P2PPeerManager.extend_known_peers)
         self.peer_manager.handle_peer_list(channel, peer_list_message)
-        self.peer_manager.extend_known_peers.assert_called_once_with({channel.peer.full_address})
 
     @patch('qrl.core.p2p.p2pPeerManager.logger', autospec=True)
     def test_handle_peer_list_empty_peer_list_message(self, logger):

--- a/tests/core/test_qrlnode.py
+++ b/tests/core/test_qrlnode.py
@@ -541,7 +541,3 @@ class TestQRLNodeProperties(TestCase):
     def test_get_peers_stat(self):
         self.qrlnode.get_peers_stat()
         self.m_peer_manager.get_peers_stat.assert_called_once()
-
-    def test_connect_peers(self):
-        self.qrlnode.connect_peers()
-        self.m_peer_manager.connect_peers.assert_called_once()


### PR DESCRIPTION
- known_peers.json only maintains 3x ip address of max_peer_limit.
- disconnected peers ip are maintained after the connected peer ip.
- peers are inserted into known_peers only after sharing the peer list.
- ports recorded in known_peers is the public_port shared by the connected peer.