### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     google-auth<2.0dev,>=1.21.1
     httplib2>=0.15.0
     service_identity==17.0.0
-    protobuf==3.15.8
+    protobuf==3.20.1
     pyopenssl==17.5.0
     six==1.13.0
     click==7.1.2


### PR DESCRIPTION
Problem with protobuf during installation (ref [github protocolbuffers] )

***error: protobuf 3.15.8 is installed but protobuf<4.0.0dev,>=3.20.1 is required by {'google-api-core'}***

[github protocolbuffers]: https://github.com/protocolbuffers/protobuf/issues/10051