### PR TITLE
Updated testnet, added code to get seed block for alt chain & updated dependencies version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: qrledger/qrl-docker-ci:xenial
+      - image: qrledger/qrl-docker-ci:bionic
     steps:
       - checkout
       - run: pip install -U setuptools
@@ -14,7 +14,7 @@ jobs:
       
   test_leaks_CLI:
     docker:
-      - image: qrledger/qrl-docker-ci:xenial
+      - image: qrledger/qrl-docker-ci:bionic
     steps:
       - checkout
       - run: pip install -U setuptools
@@ -25,7 +25,7 @@ jobs:
 
   flake8:
     docker:
-      - image: qrledger/qrl-docker-ci:xenial
+      - image: qrledger/qrl-docker-ci:bionic
     steps:
       - checkout
       - run: pip install -U setuptools
@@ -33,7 +33,7 @@ jobs:
 
   test_leaks_other:
     docker:
-      - image: qrledger/qrl-docker-ci:xenial
+      - image: qrledger/qrl-docker-ci:bionic
     steps:
       - checkout
       - run: pip install -U setuptools
@@ -41,17 +41,6 @@ jobs:
       - run: pip install -U -r test-requirements.txt
       - run: pip install -U pytest-openfiles pytest-leaks pytest-threadleak pytest-repeat
       - run: python3 setup.py test --addopts "--ignore=tests/tools/ --ignore=tests/daemon/ --ignore=tests/services/test_WalletAPIService.py --open-files --threadleak -n0"
-
-  build_trusty:
-    docker:
-      - image: qrledger/qrl-docker-ci:trusty
-    steps:
-      - checkout
-      - run: pip install -U setuptools
-      - run: pip install -U -r requirements.txt
-      - run: pip install -U -r test-requirements.txt
-      - run: python3 --version
-      - run: python3 setup.py test
 
   build_bionic:
     docker:
@@ -65,7 +54,7 @@ jobs:
 
   integration_fast:
     docker:
-      - image: qrledger/qrl-docker-ci:xenial
+      - image: qrledger/qrl-docker-ci:bionic
     environment:
       PYTHONPATH: /root/project:/root/project/tests_integration
       TESTINPLACE: 1
@@ -79,7 +68,7 @@ jobs:
 
   integration_smoke:
     docker:
-      - image: qrledger/qrl-docker-ci:xenial
+      - image: qrledger/qrl-docker-ci:bionic
     environment:
       PYTHONPATH: /root/project:/root/project/tests_integration
       TESTINPLACE: 1
@@ -119,7 +108,7 @@ jobs:
 
   deploy-pypi:
     docker:
-      - image: qrledger/qrl-docker-ci:xenial
+      - image: qrledger/qrl-docker-ci:bionic
     steps:
       - checkout
       - run: git submodule update --init --recursive

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,7 @@ jobs:
       TESTINPLACE: 1
     steps:
       - checkout
+      - run: apt-get update
       - run: apt-get install -y rsync
       - run: git submodule update --init --recursive --remote
       - run: apt install -y python3-venv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,7 @@ jobs:
       TESTINPLACE: 1
     steps:
       - checkout
+      - run: apt-get install -y rsync
       - run: git submodule update --init --recursive --remote
       - run: apt install -y python3-venv
       - run: pip install -U -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,5 @@ Flask>=2.0.0,<=2.2.2
 json-rpc==1.13.0
 idna==2.6
 cryptography==2.3
-mock==2.0.0
+mock>=2.0.0
 daemonize==2.4.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Fixing sphinx version due to https://github.com/sphinx-doc/sphinx/issues/3976
 # setuptools==50.3.2 # It needs to be installed manually in some cases
-plyvel==1.4.0
+plyvel>=1.2.0,<=1.4.0
 ntplib==0.3.4
 Twisted==20.3.0
 colorlog==3.1.0
@@ -12,15 +12,15 @@ google-api-python-client==1.8.3
 google-auth<2.0dev,>=1.21.1
 httplib2>=0.15.0
 service_identity==17.0.0
-protobuf==3.20.3
+protobuf>3.19.0,<=3.20.3
 pyopenssl==17.5.0
 six==1.13.0
-click==7.1.2
+click==8.0
 pyqrllib>=1.2.3,<1.3.0
 pyqryptonight>=0.99.9
 pyqrandomx>=0.3.0,<1.0.0
-Flask>=1.0.0,<=1.1.2
-json-rpc==1.10.8
+Flask>=2.0.0,<=2.2.2
+json-rpc==1.13.0
 idna==2.6
 cryptography==2.3
 mock==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,18 @@
 # Fixing sphinx version due to https://github.com/sphinx-doc/sphinx/issues/3976
 # setuptools==50.3.2 # It needs to be installed manually in some cases
-plyvel==1.2.0
+plyvel==1.4.0
 ntplib==0.3.4
 Twisted==20.3.0
 colorlog==3.1.0
 simplejson==3.11.1
 PyYAML==5.3.1
-grpcio-tools>=1.9.0,<=1.27.2
-grpcio>=1.9.0,<=1.27.2
+grpcio-tools>=1.9.0,<=1.50.0
+grpcio>=1.9.0,<=1.50.0
 google-api-python-client==1.8.3
 google-auth<2.0dev,>=1.21.1
 httplib2>=0.15.0
 service_identity==17.0.0
-protobuf==3.15.8
+protobuf==3.20.3
 pyopenssl==17.5.0
 six==1.13.0
 click==7.1.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ install_requires =
     json-rpc==1.13.0
     idna==2.6
     cryptography==2.3
-    mock==2.0.0
+    mock>=2.0.0
     daemonize==2.4.7
 
 # Add here test requirements (semicolon-separated)

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,19 +26,19 @@ package_dir =
 # install_requires = numpy; scipy
 install_requires =
     # setuptools==50.3.2
-    plyvel==1.2.0
+    plyvel==1.4.0
     ntplib==0.3.4
     Twisted==20.3.0
     colorlog==3.1.0
     simplejson==3.11.1
     PyYAML==5.3.1
-    grpcio-tools>=1.9.0,<=1.27.2
-    grpcio>=1.9.0,<=1.27.2
+    grpcio-tools>=1.9.0,<=1.50.0
+    grpcio>=1.9.0,<=1.50.0
     google-api-python-client==1.8.3
     google-auth<2.0dev,>=1.21.1
     httplib2>=0.15.0
     service_identity==17.0.0
-    protobuf==3.15.8
+    protobuf==3.20.3
     pyopenssl==17.5.0
     six==1.13.0
     click==7.1.2
@@ -54,9 +54,9 @@ install_requires =
 
 # Add here test requirements (semicolon-separated)
 tests_require =
-    pytest==3.6
-    pytest-cov==2.5.1
-    pytest-xdist==1.22.2
+    pytest==7.1.3
+    pytest-cov==4.0.0
+    pytest-xdist==2.5.0
     pytest-flake8==1.0.0
     flake8==3.5.0
     autoflake==1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ package_dir =
 # install_requires = numpy; scipy
 install_requires =
     # setuptools==50.3.2
-    plyvel==1.4.0
+    plyvel>=1.2.0,<=1.4.0
     ntplib==0.3.4
     Twisted==20.3.0
     colorlog==3.1.0
@@ -38,15 +38,15 @@ install_requires =
     google-auth<2.0dev,>=1.21.1
     httplib2>=0.15.0
     service_identity==17.0.0
-    protobuf==3.20.3
+    protobuf>3.19.0,<=3.20.3
     pyopenssl==17.5.0
     six==1.13.0
-    click==7.1.2
+    click==8.0
     pyqrllib>=1.2.3,<1.3.0
     pyqryptonight>=0.99.9
     pyqrandomx>=0.3.0,<1.0.0
-    Flask>=1.0.0,<=1.1.2
-    json-rpc==1.10.8
+    Flask>=2.0.0,<=2.2.2
+    json-rpc==1.13.0
     idna==2.6
     cryptography==2.3
     mock==2.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ install_requires =
 
 # Add here test requirements (semicolon-separated)
 tests_require =
-    pytest==7.1.3
+    pytest>=7.0.0,<=7.1.3
     pytest-cov==4.0.0
     pytest-xdist==2.5.0
     pytest-flake8==1.0.0

--- a/src/qrl/core/config.py
+++ b/src/qrl/core/config.py
@@ -313,7 +313,7 @@ class DevConfig(object):
         # ======================================
         self.hard_fork_heights = [942375, 1938000, 2078800]
         self.hard_fork_node_disconnect_delay = [0, 0, 2880]
-        self.testnet_hard_fork_heights = [1, 3000, 3000]
+        self.testnet_hard_fork_heights = [0, 0, 0]
         self.testnet_hard_fork_node_disconnect_delay = [0, 0, 0]
 
         # ======================================

--- a/src/qrl/core/config.py
+++ b/src/qrl/core/config.py
@@ -313,7 +313,8 @@ class DevConfig(object):
         # ======================================
         self.hard_fork_heights = [942375, 1938000, 2078800]
         self.hard_fork_node_disconnect_delay = [0, 0, 2880]
-        self.testnet_hard_fork_heights = [1, 3000]
+        self.testnet_hard_fork_heights = [1, 3000, 3000]
+        self.testnet_hard_fork_node_disconnect_delay = [0, 0, 0]
 
         # ======================================
         # PROPOSAL CONFIG

--- a/src/qrl/core/misc/expiring_set.py
+++ b/src/qrl/core/misc/expiring_set.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 # Distributed under the MIT software license, see the accompanying
 # file LICENSE or http://www.opensource.org/licenses/mit-license.php.
-from collections import Set
+from collections.abc import Set
 
 import simplejson as json
 

--- a/src/qrl/main.py
+++ b/src/qrl/main.py
@@ -68,7 +68,10 @@ def main():
     qrl_dir_post_fix = ''
     copy_files = []
     if args.network_type == 'testnet':
-        config.dev.hard_fork_heights = list(config.dev.testnet_hard_fork_heights)  # Hard Fork Block Height For Testnet
+        # Hard Fork Block Height For Testnet
+        config.dev.hard_fork_heights = list(config.dev.testnet_hard_fork_heights)
+        # Hard Fork Block Height Disconnect Delay For Testnet
+        config.dev.hard_fork_node_disconnect_delay = list(config.dev.testnet_hard_fork_node_disconnect_delay)
         qrl_dir_post_fix = '-testnet'
         package_directory = os.path.dirname(os.path.abspath(__file__))
         copy_files.append(os.path.join(package_directory, 'network/testnet/genesis.yml'))

--- a/src/qrl/network/testnet/config.yml
+++ b/src/qrl/network/testnet/config.yml
@@ -1,4 +1,13 @@
 peer_list: [ "18.130.83.207", "209.250.246.234", "136.244.104.146", "95.179.154.132" ]
-genesis_prev_headerhash: 'Testnet 2022'
-genesis_timestamp: 1641963062
+genesis_prev_headerhash: 'Final Testnet'
+genesis_timestamp: 1668696491
 genesis_difficulty: 5000
+p2p_local_port: 29000
+p2p_public_port: 29000
+admin_api_port: 29008
+public_api_port: 29009
+mining_api_port: 29007
+grpc_proxy_port: 28090
+wallet_daemon_port: 28091
+public_api_server: "127.0.0.1:29009"
+wallet_api_port: 29010

--- a/src/qrl/network/testnet/genesis.yml
+++ b/src/qrl/network/testnet/genesis.yml
@@ -2,11 +2,11 @@ genesisBalance:
 - address: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
   balance: '105000000000000000'
 header:
-  hashHeader: LGyQSHq8RYrEHmG7VVtmc9YIqHNxFIH9IMrUTo34lJ0=
-  hashHeaderPrev: VGVzdG5ldCAyMDIy
+  hashHeader: 1nZdbgr36LJbrFhyeZmeFruwvTA4RFk04tnzskqJBB4=
+  hashHeaderPrev: RmluYWwgVGVzdG5ldA==
   merkleRoot: wquld1GTaqfKWRhAdWpOeREWVdCmlTYIAUrY9eWGwTQ=
   rewardBlock: '65000000000000000'
-  timestampSeconds: '1641963062'
+  timestampSeconds: '1668696491'
 transactions:
 - coinbase:
     addrTo: AQYA3oDYKOMv8cfAHpT2zewSkuiz/0gYQy5+atQfOsdD57loCQog

--- a/src/qrl/tools/generate_genesis.py
+++ b/src/qrl/tools/generate_genesis.py
@@ -57,14 +57,12 @@ def get_migration_transactions(signing_xmss, filename):
 
 
 def main():
+    exclude_migration_tx = False
     if len(sys.argv) > 2:
         print("Unexpected arguments")
         sys.exit(0)
     elif len(sys.argv) == 1:
-        print("Missing Filename")
-        sys.exit(0)
-
-    filename = sys.argv[1]
+        exclude_migration_tx = True
 
     if sys.version_info.major > 2:
         seed = bytes(hstr2bin(input('Enter extended hexseed: ')))
@@ -73,7 +71,10 @@ def main():
 
     dist_xmss = XMSS.from_extended_seed(seed)
 
-    transactions = get_migration_transactions(signing_xmss=dist_xmss, filename=filename)
+    transactions = []
+    if not exclude_migration_tx:
+        filename = sys.argv[1]
+        transactions = get_migration_transactions(signing_xmss=dist_xmss, filename=filename)
 
     block = Block.create(dev_config=config.dev,
                          block_number=0,

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,7 @@
 # Add requirements only needed for your unittests and during development here.
 # They will be installed automatically when running `python setup.py test`.
 # ATTENTION: Don't remove pytest-cov and pytest as they are needed.
-pytest==7.1.3
+pytest>=7.0.0,<=7.1.3
 pytest-cov==4.0.0
 pytest-xdist==2.5.0
 flake8==3.5.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,9 +1,9 @@
 # Add requirements only needed for your unittests and during development here.
 # They will be installed automatically when running `python setup.py test`.
 # ATTENTION: Don't remove pytest-cov and pytest as they are needed.
-pytest==3.6
-pytest-cov==2.5.1
-pytest-xdist==1.22.2
+pytest==7.1.3
+pytest-cov==4.0.0
+pytest-xdist==2.5.0
 flake8==3.5.0
 autoflake==1.1
 timeout-decorator==0.4.0


### PR DESCRIPTION
- Added config for new testnet
- Different ports for testnet node compared to mainnet, so that one can run both on same machine without port conflict
- Updated dependencies versions to make it compatible with Ubuntu 22+
- get_seed_block now also finds the seed block for the alt chain
- Updated integration tests