### PR TITLE
test: regression test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   build:
     docker:
@@ -129,7 +129,6 @@ jobs:
       - run: twine upload -u $PYPI_USERNAME -p $PYPI_PASSWORD dist/*
 
 workflows:
-  version: 2
   build_all:
     jobs:
       - build:

--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -1,0 +1,11 @@
+# Prospector profile, used by Codacy's Prospector_pydocstyle analysis.
+#
+# pydocstyle ships D212 and D213 as mutually exclusive alternatives:
+#   D212 - multi-line docstring summary should start at the first line
+#   D213 - multi-line docstring summary should start at the second line
+# Codacy's default profile enables both, so every multi-line docstring reports
+# one of them whichever layout it uses. We follow D212, so D213 is disabled.
+pydocstyle:
+  run: true
+  disable:
+    - D213

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ pyqrllib>=1.2.3,<1.3.0
 pyqryptonight>=0.99.9
 pyqrandomx>=0.3.0,<1.0.0
 Flask>=2.0.0,<=2.2.2
+Werkzeug<=2.3.8
 json-rpc==1.13.0
 idna==2.6
 cryptography==2.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ install_requires =
     pyqryptonight>=0.99.9
     pyqrandomx>=0.3.0,<1.0.0
     Flask>=2.0.0,<=2.2.2
+    Werkzeug<=2.3.8
     json-rpc==1.13.0
     idna==2.6
     cryptography==2.3

--- a/src/qrl/core/Block.py
+++ b/src/qrl/core/Block.py
@@ -1,6 +1,8 @@
 # coding=utf-8
 # Distributed under the MIT software license, see the accompanying
 # file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+"""Block: the on-chain block structure — assembly (create), consensus validation
+(validate), and helpers for persisting and reading blocks from the state DB."""
 from collections import OrderedDict
 from statistics import median
 from typing import Optional
@@ -123,6 +125,9 @@ class Block(object):
                miner_address: bytes,
                seed_height: Optional[int],
                seed_hash: Optional[bytes]):
+        """Assemble a new block: prepend the coinbase (block reward + summed
+        transaction fees) to the given transactions, build the transaction merkle
+        root, and create the matching header with mining nonces zeroed."""
 
         block = Block()
 
@@ -163,6 +168,8 @@ class Block(object):
         return block
 
     def update_mining_address(self, dev_config: DevConfig, mining_address: bytes):
+        """Point the coinbase at a new miner address and recompute the header's
+        merkle root accordingly (used by the miner before submitting a block)."""
         coinbase_tx = Transaction.from_pbdata(self.transactions[0])
         coinbase_tx.update_mining_address(mining_address)
         hashedtransactions = []
@@ -175,6 +182,14 @@ class Block(object):
         self._data.header.MergeFrom(self.blockheader.pbdata)
 
     def validate(self, chain_manager, future_blocks: OrderedDict) -> bool:
+        """Fully validate a received block against consensus rules.
+
+        Rejects duplicates and blocks with an unknown parent, checks the
+        parent/child relation and the proof-of-work, requires exactly one
+        coinbase (except the historical block 2078158), then rebuilds the
+        transaction merkle root and fee reward from the block's transactions and
+        confirms the header agrees. Returns True only if every check passes.
+        """
         if chain_manager.get_block_is_duplicate(self):
             logger.warning('Duplicate Block #%s %s', self.block_number, bin2hstr(self.headerhash))
             return False
@@ -275,6 +290,8 @@ class Block(object):
 
     @staticmethod
     def get_block_size_limit(state: State, block, dev_config: DevConfig):
+        """Return the allowed block size: the median size of the last 10 blocks,
+        clamped between the configured min and max block-size limits."""
         # NOTE: Miner
         block_size_list = []
         for _ in range(0, 10):

--- a/src/qrl/core/Block.py
+++ b/src/qrl/core/Block.py
@@ -1,8 +1,10 @@
 # coding=utf-8
 # Distributed under the MIT software license, see the accompanying
 # file LICENSE or http://www.opensource.org/licenses/mit-license.php.
-"""Block: the on-chain block structure — assembly (create), consensus validation
-(validate), and helpers for persisting and reading blocks from the state DB."""
+"""
+Block: the on-chain block structure — assembly (create), consensus validation
+(validate), and helpers for persisting and reading blocks from the state DB.
+"""
 from collections import OrderedDict
 from statistics import median
 from typing import Optional
@@ -125,9 +127,11 @@ class Block(object):
                miner_address: bytes,
                seed_height: Optional[int],
                seed_hash: Optional[bytes]):
-        """Assemble a new block: prepend the coinbase (block reward + summed
+        """
+        Assemble a new block: prepend the coinbase (block reward + summed
         transaction fees) to the given transactions, build the transaction merkle
-        root, and create the matching header with mining nonces zeroed."""
+        root, and create the matching header with mining nonces zeroed.
+        """
 
         block = Block()
 
@@ -168,8 +172,10 @@ class Block(object):
         return block
 
     def update_mining_address(self, dev_config: DevConfig, mining_address: bytes):
-        """Point the coinbase at a new miner address and recompute the header's
-        merkle root accordingly (used by the miner before submitting a block)."""
+        """
+        Point the coinbase at a new miner address and recompute the header's
+        merkle root accordingly (used by the miner before submitting a block).
+        """
         coinbase_tx = Transaction.from_pbdata(self.transactions[0])
         coinbase_tx.update_mining_address(mining_address)
         hashedtransactions = []
@@ -182,7 +188,8 @@ class Block(object):
         self._data.header.MergeFrom(self.blockheader.pbdata)
 
     def validate(self, chain_manager, future_blocks: OrderedDict) -> bool:
-        """Fully validate a received block against consensus rules.
+        """
+        Fully validate a received block against consensus rules.
 
         Rejects duplicates and blocks with an unknown parent, checks the
         parent/child relation and the proof-of-work, requires exactly one
@@ -290,8 +297,10 @@ class Block(object):
 
     @staticmethod
     def get_block_size_limit(state: State, block, dev_config: DevConfig):
-        """Return the allowed block size: the median size of the last 10 blocks,
-        clamped between the configured min and max block-size limits."""
+        """
+        Return the allowed block size: the median size of the last 10 blocks,
+        clamped between the configured min and max block-size limits.
+        """
         # NOTE: Miner
         block_size_list = []
         for _ in range(0, 10):

--- a/src/qrl/core/Block.py
+++ b/src/qrl/core/Block.py
@@ -1,9 +1,10 @@
 # coding=utf-8
 # Distributed under the MIT software license, see the accompanying
 # file LICENSE or http://www.opensource.org/licenses/mit-license.php.
-"""
-Block: the on-chain block structure — assembly (create), consensus validation
-(validate), and helpers for persisting and reading blocks from the state DB.
+"""Block: the on-chain block structure.
+
+Assembly (create), consensus validation (validate), and helpers for persisting
+and reading blocks from the state DB.
 """
 from collections import OrderedDict
 from statistics import median
@@ -127,12 +128,12 @@ class Block(object):
                miner_address: bytes,
                seed_height: Optional[int],
                seed_hash: Optional[bytes]):
-        """
-        Assemble a new block: prepend the coinbase (block reward + summed
-        transaction fees) to the given transactions, build the transaction merkle
-        root, and create the matching header with mining nonces zeroed.
-        """
+        """Assemble a new block.
 
+        Prepend the coinbase (block reward + summed transaction fees) to the given
+        transactions, build the transaction merkle root, and create the matching
+        header with mining nonces zeroed.
+        """
         block = Block()
 
         # Process transactions

--- a/src/qrl/core/ChainManager.py
+++ b/src/qrl/core/ChainManager.py
@@ -1,10 +1,10 @@
 # coding=utf-8
 # Distributed under the MIT software license, see the accompanying
 # file LICENSE or http://www.opensource.org/licenses/mit-license.php.
-"""
-ChainManager: owns the chain's state — adding and validating blocks, fork
-detection and recovery, and applying/reverting transaction state changes against
-the state DB.
+"""ChainManager: owns the chain's state.
+
+Adding and validating blocks, fork detection and recovery, and applying/reverting
+transaction state changes against the state DB.
 """
 import sys
 import threading

--- a/src/qrl/core/ChainManager.py
+++ b/src/qrl/core/ChainManager.py
@@ -1,9 +1,11 @@
 # coding=utf-8
 # Distributed under the MIT software license, see the accompanying
 # file LICENSE or http://www.opensource.org/licenses/mit-license.php.
-"""ChainManager: owns the chain's state — adding and validating blocks, fork
+"""
+ChainManager: owns the chain's state — adding and validating blocks, fork
 detection and recovery, and applying/reverting transaction state changes against
-the state DB."""
+the state DB.
+"""
 import sys
 import threading
 from collections import OrderedDict
@@ -630,8 +632,10 @@ class ChainManager:
                 self._state.put_state_version()
 
     def _update_chainstate(self, block: Block, batch):
-        """Make `block` the new chain tip: update the last-block/height pointers,
-        remove its transactions from the pool, and write transaction metadata."""
+        """
+        Make `block` the new chain tip: update the last-block/height pointers,
+        remove its transactions from the pool, and write transaction metadata.
+        """
         self._last_block = block
         self._update_block_number_mapping(block, batch)
         self.tx_pool.remove_tx_in_block_from_pool(block)
@@ -819,7 +823,8 @@ class ChainManager:
             return True
 
     def _fork_recovery(self, block: Block, fork_state: qrlstateinfo_pb2.ForkState) -> bool:
-        """Switch the main chain to the branch ending at `block` when it wins.
+        """
+        Switch the main chain to the branch ending at `block` when it wins.
 
         Finds the fork point, rolls the state back to it, and replays the new
         branch; if replay fails it restores the old chain. Fork progress is
@@ -882,10 +887,12 @@ class ChainManager:
         return self._try_branch_add_block(block, dev_config, check_stale)
 
     def add_block(self, block: Block, check_stale=True) -> bool:
-        """Add a block to the chain (thread-safe entry point).
+        """
+        Add a block to the chain (thread-safe entry point).
 
         Skips blocks below the re-org limit or already known, then delegates to
-        _add_block. Returns True only if the block was added."""
+        _add_block. Returns True only if the block was added.
+        """
         with self.lock:
             if block.block_number <= self.re_org_limit:
                 logger.debug('Skipping block #%s as beyond re-org limit', block.block_number)
@@ -1063,9 +1070,11 @@ class ChainManager:
                                       votes_stats)
 
     def _apply_state_changes(self, block, batch) -> bool:
-        """Validate and apply every transaction in `block` to the state, updating
+        """
+        Validate and apply every transaction in `block` to the state, updating
         balances and paginated indexes. Rejects a second coinbase (except the
-        historical block 2078158). Returns False if any transaction is invalid."""
+        historical block 2078158). Returns False if any transaction is invalid.
+        """
         state_container = self.new_state_container(set(),
                                                    block.block_number,
                                                    True,
@@ -1336,8 +1345,10 @@ class ChainManager:
         return data_point
 
     def get_unused_ots_index2(self, address, start_ots_index=0):
-        """Convenience wrapper for get_unused_ots_index that reads bitfield pages
-        straight from the state DB (no pre-loaded caches)."""
+        """
+        Convenience wrapper for get_unused_ots_index that reads bitfield pages
+        straight from the state DB (no pre-loaded caches).
+        """
         return self.get_unused_ots_index(addresses_bitfield=dict(),
                                          addresses_state=dict(),
                                          address=address,

--- a/src/qrl/core/ChainManager.py
+++ b/src/qrl/core/ChainManager.py
@@ -789,6 +789,21 @@ class ChainManager:
                 if not self._apply_state_changes(block, batch):
                     return False
 
+                # Re-persist the block after applying it. _apply_state_changes()
+                # mutates apply-time transaction fields on the in-memory block
+                # object (e.g. MultiSigVote.prev_tx_hash, which is derived from
+                # VoteStats during application and is not part of the signed tx
+                # data). On the canonical-tip path these mutations are already
+                # captured because _try_branch_add_block() applies before it
+                # calls put_block(). A side branch, however, is persisted before
+                # it is applied, so without re-persisting here the stored block
+                # bytes stay stale. A later reorg or restart that rolls this
+                # block back loads the stale bytes and feeds an inconsistent
+                # prev_tx_hash into VoteStats.revert_vote_stats(), corrupting
+                # vote history. Writing the normalized block back keeps storage
+                # consistent with applied state.
+                Block.put_block(self._state, block, batch)
+
                 self._update_chainstate(block, batch)
 
                 logger.debug('Apply block #%d - [batch %d | %s]', block.block_number, i, hash_path[i])

--- a/src/qrl/core/ChainManager.py
+++ b/src/qrl/core/ChainManager.py
@@ -1,6 +1,9 @@
 # coding=utf-8
 # Distributed under the MIT software license, see the accompanying
 # file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+"""ChainManager: owns the chain's state — adding and validating blocks, fork
+detection and recovery, and applying/reverting transaction state changes against
+the state DB."""
 import sys
 import threading
 from collections import OrderedDict
@@ -627,6 +630,8 @@ class ChainManager:
                 self._state.put_state_version()
 
     def _update_chainstate(self, block: Block, batch):
+        """Make `block` the new chain tip: update the last-block/height pointers,
+        remove its transactions from the pool, and write transaction metadata."""
         self._last_block = block
         self._update_block_number_mapping(block, batch)
         self.tx_pool.remove_tx_in_block_from_pool(block)
@@ -814,6 +819,13 @@ class ChainManager:
             return True
 
     def _fork_recovery(self, block: Block, fork_state: qrlstateinfo_pb2.ForkState) -> bool:
+        """Switch the main chain to the branch ending at `block` when it wins.
+
+        Finds the fork point, rolls the state back to it, and replays the new
+        branch; if replay fails it restores the old chain. Fork progress is
+        persisted in `fork_state` so an interrupted recovery can resume. Returns
+        True on a successful switch, False if it bailed (e.g. beyond re-org limit).
+        """
         logger.info("Triggered Fork Recovery")
         # This condition only becomes true, when fork recovery was interrupted
         if fork_state.fork_point_headerhash:
@@ -858,6 +870,7 @@ class ChainManager:
         return True
 
     def _add_block(self, block, check_stale=True) -> bool:
+        """Enforce the block-size limit, then attempt to add the block to a branch."""
         dev_config = self.get_config_by_block_number(block.block_number)
         self.trigger_miner = False
 
@@ -869,6 +882,10 @@ class ChainManager:
         return self._try_branch_add_block(block, dev_config, check_stale)
 
     def add_block(self, block: Block, check_stale=True) -> bool:
+        """Add a block to the chain (thread-safe entry point).
+
+        Skips blocks below the re-org limit or already known, then delegates to
+        _add_block. Returns True only if the block was added."""
         with self.lock:
             if block.block_number <= self.re_org_limit:
                 logger.debug('Skipping block #%s as beyond re-org limit', block.block_number)
@@ -1046,6 +1063,9 @@ class ChainManager:
                                       votes_stats)
 
     def _apply_state_changes(self, block, batch) -> bool:
+        """Validate and apply every transaction in `block` to the state, updating
+        balances and paginated indexes. Rejects a second coinbase (except the
+        historical block 2078158). Returns False if any transaction is invalid."""
         state_container = self.new_state_container(set(),
                                                    block.block_number,
                                                    True,
@@ -1316,6 +1336,8 @@ class ChainManager:
         return data_point
 
     def get_unused_ots_index2(self, address, start_ots_index=0):
+        """Convenience wrapper for get_unused_ots_index that reads bitfield pages
+        straight from the state DB (no pre-loaded caches)."""
         return self.get_unused_ots_index(addresses_bitfield=dict(),
                                          addresses_state=dict(),
                                          address=address,

--- a/src/qrl/core/ChainManager.py
+++ b/src/qrl/core/ChainManager.py
@@ -1213,6 +1213,13 @@ class ChainManager:
             elif MultiSigAddressState.address_is_valid(address):
                 multi_sig_address_state = MultiSigAddressState.get_multi_sig_address_state_by_address(self._state._db,
                                                                                                       address)
+                # A syntactically valid multi-sig address (0x11 prefix, valid checksum) need not
+                # exist in the DB - e.g. a transfer whose addr_to is a crafted nonexistent multi-sig
+                # address. Reject cleanly here instead of dereferencing None on .signatories below
+                # (consistent with the `return None, False` rejections elsewhere in this method).
+                # This lets the transaction fail validation gracefully rather than raising.
+                if multi_sig_address_state is None:
+                    return None, False
                 addresses_state[address] = multi_sig_address_state
 
                 # Load Address State of signatories as it needs to be processed by MultiSigSpend Txn

--- a/src/qrl/core/txs/CoinBase.py
+++ b/src/qrl/core/txs/CoinBase.py
@@ -43,6 +43,7 @@ class CoinBase(Transaction):
         transaction._data.coinbase.addr_to = miner_address
         transaction._data.coinbase.amount = amount
         transaction._data.nonce = block_number + 1
+        # Coinbase stores get_data_hash() directly as its transaction_hash.
         transaction._data.transaction_hash = transaction.get_data_hash()
 
         transaction.validate_or_raise(verify_signature=False)
@@ -73,6 +74,12 @@ class CoinBase(Transaction):
 
         if self.fee != 0:
             logger.warning('Fee for coinbase transaction should be 0')
+            return False
+
+        if self.txhash != self.get_data_hash():
+            logger.warning('Invalid coinbase transaction hash')
+            logger.warning('Expected %s', bin2hstr(self.get_data_hash()))
+            logger.warning('Found    %s', bin2hstr(self.txhash))
             return False
 
         return True

--- a/src/qrl/core/txs/MessageTransaction.py
+++ b/src/qrl/core/txs/MessageTransaction.py
@@ -27,10 +27,7 @@ class MessageTransaction(Transaction):
 
     def get_data_bytes(self):
         """Return the byte string that is hashed and signed for this transaction."""
-        return self.master_addr + \
-               self.fee.to_bytes(8, byteorder='big', signed=False) + \
-               self.message_hash + \
-               self.addr_to
+        return self.master_addr + self.fee.to_bytes(8, byteorder='big', signed=False) + self.message_hash + self.addr_to
 
     @staticmethod
     def create(message_hash: bytes, addr_to: Union[bytes, None], fee: int, xmss_pk: bytes, master_addr: bytes = None):

--- a/src/qrl/core/txs/MessageTransaction.py
+++ b/src/qrl/core/txs/MessageTransaction.py
@@ -26,6 +26,7 @@ class MessageTransaction(Transaction):
         return self._data.message.addr_to
 
     def get_data_bytes(self):
+        """Return the byte string that is hashed and signed for this transaction."""
         return self.master_addr + \
                self.fee.to_bytes(8, byteorder='big', signed=False) + \
                self.message_hash + \
@@ -55,7 +56,7 @@ class MessageTransaction(Transaction):
             return False
 
         if len(self.message_hash) == 0:
-            logger.warning('Message cannot be empty')
+            logger.warning('[MessageTransaction] Message cannot be empty')
             return False
 
         if len(self.addr_to) > 0 and not (OptimizedAddressState.address_is_valid(self.addr_to)):
@@ -75,8 +76,9 @@ class MessageTransaction(Transaction):
                 return False
 
         if len(self.message_hash) > state_container.current_dev_config.message_max_length:  # TODO: Move to dev config
-            logger.warning('Message length cannot be more than %s', state_container.current_dev_config.message_max_length)
-            logger.warning('Found message length %s', len(self.message_hash))
+            logger.warning('[MessageTransaction] Message length cannot be more than %s',
+                           state_container.current_dev_config.message_max_length)
+            logger.warning('[MessageTransaction] Found message length %s', len(self.message_hash))
             return False
 
         tx_balance = state_container.addresses_state[self.addr_from].balance
@@ -96,6 +98,7 @@ class MessageTransaction(Transaction):
     def apply(self,
               state: State,
               state_container: StateContainer) -> bool:
+        """Debit the sender's fee and, if addr_to is set, record the message for the recipient."""
         address_state = state_container.addresses_state[self.addr_from]
         address_state.update_balance(state_container, self.fee, subtract=True)
         state_container.paginated_tx_hash.insert(address_state, self.txhash)
@@ -112,6 +115,7 @@ class MessageTransaction(Transaction):
     def revert(self,
                state: State,
                state_container: StateContainer) -> bool:
+        """Undo apply(): refund the sender's fee and remove the recipient's message record."""
         address_state = state_container.addresses_state[self.addr_from]
         address_state.update_balance(state_container, self.fee)
         state_container.paginated_tx_hash.remove(address_state, self.txhash)

--- a/src/qrl/core/txs/TokenTransaction.py
+++ b/src/qrl/core/txs/TokenTransaction.py
@@ -112,6 +112,14 @@ class TokenTransaction(Transaction):
                 logger.warning('Address %s | Amount %s', initial_balance.address, initial_balance.amount)
                 return False
 
+        # The total token supply is fixed at creation and conserved across transfers,
+        # so no address's uint64 token balance can ever overflow as long as the total
+        # supply itself fits in uint64.
+        if sum_of_initial_balances > 2 ** 64 - 1:
+            logger.warning('Sum of initial balances exceeds maximum uint64')
+            logger.warning('Sum of initial balances %s', sum_of_initial_balances)
+            return False
+
         allowed_decimals = self.calc_allowed_decimals(sum_of_initial_balances // 10 ** self.decimals)
 
         if self.decimals > allowed_decimals:

--- a/src/qrl/core/txs/TransferTransaction.py
+++ b/src/qrl/core/txs/TransferTransaction.py
@@ -41,16 +41,17 @@ class TransferTransaction(Transaction):
         return self._data.transfer.message_data
 
     def get_data_bytes(self):
-        tmptxhash = (self.master_addr +
-                     self.fee.to_bytes(8, byteorder='big', signed=False) +
-                     self.message_data)
+        """Return the byte string that is hashed and signed for this transaction."""
+        data_bytes = (self.master_addr +
+                      self.fee.to_bytes(8, byteorder='big', signed=False) +
+                      self.message_data)
 
         for index in range(0, len(self.addrs_to)):
-            tmptxhash = (tmptxhash +
-                         self.addrs_to[index] +
-                         self.amounts[index].to_bytes(8, byteorder='big', signed=False))
+            data_bytes = (data_bytes +
+                          self.addrs_to[index] +
+                          self.amounts[index].to_bytes(8, byteorder='big', signed=False))
 
-        return tmptxhash
+        return data_bytes
 
     @staticmethod
     def create(addrs_to: list, amounts: list, message_data: Union[bytes, None], fee: int, xmss_pk, master_addr: bytes = None):
@@ -82,8 +83,7 @@ class TransferTransaction(Transaction):
 
         for amount in self.amounts:
             if amount == 0:
-                logger.warning('Amount cannot be 0 - %s', self.amounts)
-                logger.warning('Invalid TransferTransaction')
+                logger.warning('[TransferTransaction] Amount cannot be 0 - %s', self.amounts)
                 return False
 
         if self.fee < 0:
@@ -154,6 +154,7 @@ class TransferTransaction(Transaction):
     def apply(self,
               state: State,
               state_container: StateContainer) -> bool:
+        """Debit the sender (total amount + fee) and credit each recipient."""
         address_state = state_container.addresses_state[self.addr_from]
         address_state.update_balance(state_container, self.total_amount + self.fee, subtract=True)
         state_container.paginated_tx_hash.insert(address_state, self.txhash)
@@ -173,6 +174,7 @@ class TransferTransaction(Transaction):
     def revert(self,
                state: State,
                state_container: StateContainer) -> bool:
+        """Undo apply(): re-credit the sender and debit each recipient."""
         address_state = state_container.addresses_state[self.addr_from]
         address_state.update_balance(state_container,
                                      self.total_amount + self.fee)

--- a/src/qrl/grpcProxy.py
+++ b/src/qrl/grpcProxy.py
@@ -56,8 +56,10 @@ def valid_payment_permission(public_stub, master_address, payment_xmss, json_sla
 
 
 def get_unused_payment_xmss(public_stub):
-    """Return a payment slave XMSS with an unused OTS key, rotating through the
-    configured slave seeds and registering the slave on the master if needed."""
+    """
+    Return a payment slave XMSS with an unused OTS key, rotating through the
+    configured slave seeds and registering the slave on the master if needed.
+    """
     global payment_slaves
     global payment_xmss
 

--- a/src/qrl/grpcProxy.py
+++ b/src/qrl/grpcProxy.py
@@ -7,7 +7,6 @@ import simplejson as json
 import grpc
 from google.protobuf.json_format import MessageToJson
 from qrl.core import config
-from qrl.core.AddressState import AddressState
 from qrl.crypto.xmss import XMSS
 from qrl.core.txs.Transaction import Transaction
 from qrl.core.txs.TransferTransaction import TransferTransaction
@@ -27,45 +26,46 @@ def read_slaves(slaves_filename):
         return slave_data
 
 
-def get_addr_state(addr: bytes) -> AddressState:
-    stub = get_public_stub()
-    response = stub.GetAddressState(request=qrl_pb2.GetAddressStateReq(address=addr))
-    return AddressState(response.state)
-
-
-def set_unused_ots_key(xmss, addr_state, start=0):
-    for i in range(start, 2 ** xmss.height):
-        if not addr_state.ots_key_reuse(i):
-            xmss.set_ots_index(i)
-            return True
+def set_unused_ots_key(public_stub, xmss, start=0):
+    # Ask the node for the next unused OTS index via the paginated GetOTS endpoint
+    # instead of pulling the whole (unpaginated) address state and scanning the
+    # bitfield client-side. page_count=0 means no bitfield pages are returned;
+    # only next_unused_ots_index is computed (server-side, above `start`).
+    response = public_stub.GetOTS(request=qrl_pb2.GetOTSReq(address=xmss.address,
+                                                            page_from=0,
+                                                            page_count=0,
+                                                            unused_ots_index_from=start))
+    if response.unused_ots_index_found:
+        xmss.set_ots_index(response.next_unused_ots_index)
+        return True
     return False
 
 
-def valid_payment_permission(public_stub, master_address_state, payment_xmss, json_slave_txn):
-    access_type = master_address_state.get_slave_permission(payment_xmss.pk)
-
-    if access_type == -1:
-        tx = Transaction.from_json(json_slave_txn)
-        public_stub.PushTransaction(request=qrl_pb2.PushTransactionReq(transaction_signed=tx.pbdata))
-        return None
-
-    if access_type == 0:
+def valid_payment_permission(public_stub, master_address, payment_xmss, json_slave_txn):
+    # IsSlave is an O(1) keyed lookup; result=True means the slave is registered
+    # on the master with access type 0 (allowed to spend). Anything else means it
+    # is not yet a valid spending slave, so push the slave-registration txn.
+    response = public_stub.IsSlave(request=qrl_pb2.IsSlaveReq(master_address=master_address,
+                                                              slave_pk=payment_xmss.pk))
+    if response.result:
         return True
 
-    return False
+    tx = Transaction.from_json(json_slave_txn)
+    public_stub.PushTransaction(request=qrl_pb2.PushTransactionReq(transaction_signed=tx.pbdata))
+    return None
 
 
 def get_unused_payment_xmss(public_stub):
+    """Return a payment slave XMSS with an unused OTS key, rotating through the
+    configured slave seeds and registering the slave on the master if needed."""
     global payment_slaves
     global payment_xmss
 
     master_address = payment_slaves[0]
-    master_address_state = get_addr_state(master_address)
 
     if payment_xmss:
-        addr_state = get_addr_state(payment_xmss.address)
-        if set_unused_ots_key(payment_xmss, addr_state, payment_xmss.ots_index):
-            if valid_payment_permission(public_stub, master_address_state, payment_xmss, payment_slaves[2]):
+        if set_unused_ots_key(public_stub, payment_xmss, payment_xmss.ots_index):
+            if valid_payment_permission(public_stub, master_address, payment_xmss, payment_slaves[2]):
                 return payment_xmss
         else:
             payment_xmss = None
@@ -74,8 +74,7 @@ def get_unused_payment_xmss(public_stub):
         unused_ots_found = False
         for slave_seed in payment_slaves[1]:
             xmss = XMSS.from_extended_seed(slave_seed)
-            addr_state = get_addr_state(xmss.address)
-            if set_unused_ots_key(xmss, addr_state):  # Unused ots_key_found
+            if set_unused_ots_key(public_stub, xmss):  # Unused ots_key_found
                 payment_xmss = xmss
                 unused_ots_found = True
                 break
@@ -83,7 +82,7 @@ def get_unused_payment_xmss(public_stub):
         if not unused_ots_found:  # Unused ots_key_found
             return None
 
-    if not valid_payment_permission(public_stub, master_address_state, payment_xmss, payment_slaves[2]):
+    if not valid_payment_permission(public_stub, master_address, payment_xmss, payment_slaves[2]):
         return None
 
     return payment_xmss

--- a/src/qrl/grpcProxy.py
+++ b/src/qrl/grpcProxy.py
@@ -56,9 +56,10 @@ def valid_payment_permission(public_stub, master_address, payment_xmss, json_sla
 
 
 def get_unused_payment_xmss(public_stub):
-    """
-    Return a payment slave XMSS with an unused OTS key, rotating through the
-    configured slave seeds and registering the slave on the master if needed.
+    """Return a payment slave XMSS with an unused OTS key.
+
+    Rotates through the configured slave seeds and registers the slave on the
+    master if needed.
     """
     global payment_slaves
     global payment_xmss

--- a/tests/core/test_ChainManager.py
+++ b/tests/core/test_ChainManager.py
@@ -510,6 +510,154 @@ class TestChainManagerReal(TestCase):
     @set_default_balance_size()
     @set_hard_fork_block_number()
     @patch('qrl.core.misc.ntp.getTime')
+    def test_add_chain_repersists_multisig_vote_prev_tx_hash(self, time_mock):
+        """
+        Regression test for multisig vote rollback corruption after a side-branch reorg.
+
+        MultiSigVote.prev_tx_hash is derived from VoteStats during apply() and is NOT
+        part of the signed transaction data. A side-branch block is persisted before it
+        is applied; when it later becomes canonical via add_chain(), apply() normalizes
+        prev_tx_hash only on the in-memory block. add_chain() must re-persist the block
+        so the stored bytes match applied state, otherwise a later rollback/restart loads
+        a stale prev_tx_hash and corrupts VoteStats.
+
+        This drives the real add_chain() -> _apply_state_changes() -> MultiSigVote.apply()
+        path and asserts the block persisted in the DB carries the normalized prev_tx_hash.
+        """
+        with patch.object(DifficultyTracker, 'get', return_value=ask_difficulty_tracker('2', config.dev)):
+            self.chain_manager.load(self.genesis_block)
+
+            extended_seed = "010300cebc4e25553afa0aab899f7838e59e18a48852fa9dfd5" \
+                            "ae78278c371902aa9e6e9c1fa8a196d2dba0cbfd2f2d212d16c"
+            random_xmss = XMSS.from_extended_seed(hstr2bin(extended_seed))
+            alice_xmss = get_alice_xmss(4)
+            bob_xmss = get_bob_xmss(4)
+            multi_sig_create = MultiSigCreate.create(signatories=[alice_xmss.address,
+                                                                  bob_xmss.address],
+                                                     weights=[4, 6],
+                                                     threshold=5,
+                                                     fee=0,
+                                                     xmss_pk=alice_xmss.pk)
+            multi_sig_create.sign(alice_xmss)
+            multi_sig_create.pbdata.nonce = 1
+            multi_sig_address = MultiSigAddressState.generate_multi_sig_address(multi_sig_create.txhash)
+
+            transfer_transaction = TransferTransaction.create(addrs_to=[multi_sig_address],
+                                                              amounts=[40 * int(config.dev.shor_per_quanta)],
+                                                              message_data=None,
+                                                              fee=1 * config.dev.shor_per_quanta,
+                                                              xmss_pk=bob_xmss.pk)
+            transfer_transaction._data.nonce = 1
+            transfer_transaction.sign(bob_xmss)
+
+            multi_sig_spend = MultiSigSpend.create(multi_sig_address=multi_sig_address,
+                                                   addrs_to=[random_xmss.address, alice_xmss.address],
+                                                   amounts=[10, 5],
+                                                   expiry_block_number=100,
+                                                   fee=0,
+                                                   xmss_pk=alice_xmss.pk)
+            multi_sig_spend.sign(alice_xmss)
+            multi_sig_spend.pbdata.nonce = 2
+
+            multi_sig_vote1 = MultiSigVote.create(shared_key=multi_sig_spend.txhash,
+                                                  unvote=False,
+                                                  fee=0,
+                                                  xmss_pk=alice_xmss.pk)
+            multi_sig_vote1.sign(alice_xmss)
+            multi_sig_vote1.pbdata.nonce = 3
+            time_mock.return_value = 1615270948  # Very high to get an easy difficulty
+
+            # Blocks 1-4 reuse the proven setup (and mining nonces) from test_add_block2
+            # to reach a real state where VoteStats records alice's vote1.
+            seed_block = self.chain_manager.get_block_by_number(self._qn.get_seed_height(1))
+            block_1 = Block.create(dev_config=config.dev, block_number=1,
+                                   prev_headerhash=self.genesis_block.headerhash,
+                                   prev_timestamp=self.genesis_block.timestamp,
+                                   transactions=[multi_sig_create], miner_address=alice_xmss.address,
+                                   seed_height=seed_block.block_number, seed_hash=seed_block.headerhash)
+            block_1.set_nonces(config.dev, 129, 0)
+            self.assertTrue(block_1.validate(self.chain_manager, {}))
+            self.assertTrue(self.chain_manager.add_block(block_1))
+
+            seed_block = self.chain_manager.get_block_by_number(self._qn.get_seed_height(2))
+            block_2 = Block.create(dev_config=config.dev, block_number=2,
+                                   prev_headerhash=block_1.headerhash, prev_timestamp=block_1.timestamp,
+                                   transactions=[transfer_transaction], miner_address=alice_xmss.address,
+                                   seed_height=seed_block.block_number, seed_hash=seed_block.headerhash)
+            block_2.set_nonces(config.dev, 129, 0)
+            self.assertTrue(block_2.validate(self.chain_manager, {}))
+            self.assertTrue(self.chain_manager.add_block(block_2))
+
+            seed_block = self.chain_manager.get_block_by_number(self._qn.get_seed_height(3))
+            block_3 = Block.create(dev_config=config.dev, block_number=3,
+                                   prev_headerhash=block_2.headerhash, prev_timestamp=block_2.timestamp,
+                                   transactions=[multi_sig_spend], miner_address=alice_xmss.address,
+                                   seed_height=seed_block.block_number, seed_hash=seed_block.headerhash)
+            block_3.set_nonces(config.dev, 0, 0)
+            self.assertTrue(block_3.validate(self.chain_manager, {}))
+            self.assertTrue(self.chain_manager.add_block(block_3))
+
+            seed_block = self.chain_manager.get_block_by_number(self._qn.get_seed_height(4))
+            block_4 = Block.create(dev_config=config.dev, block_number=4,
+                                   prev_headerhash=block_3.headerhash, prev_timestamp=block_3.timestamp,
+                                   transactions=[multi_sig_vote1], miner_address=alice_xmss.address,
+                                   seed_height=seed_block.block_number, seed_hash=seed_block.headerhash)
+            block_4.set_nonces(config.dev, 0, 0)
+            self.assertTrue(block_4.validate(self.chain_manager, {}))
+            self.assertTrue(self.chain_manager.add_block(block_4))
+            self.assertEqual(self.chain_manager.last_block, block_4)
+
+            # VoteStats now records alice's vote1 as her current vote.
+            vote_stats = self.chain_manager.get_vote_stats(multi_sig_spend.txhash)
+            self.assertEqual(vote_stats.get_vote_tx_hash_by_signatory_address(alice_xmss.address),
+                             multi_sig_vote1.txhash)
+
+            # Alice now casts an unvote. Applied against the post-block_4 state, its
+            # derived prev_tx_hash MUST normalize to vote1's txhash.
+            multi_sig_unvote = MultiSigVote.create(shared_key=multi_sig_spend.txhash,
+                                                   unvote=True,
+                                                   fee=0,
+                                                   xmss_pk=alice_xmss.pk)
+            multi_sig_unvote.sign(alice_xmss)
+            multi_sig_unvote.pbdata.nonce = 4
+
+            seed_block = self.chain_manager.get_block_by_number(self._qn.get_seed_height(5))
+            side_block = Block.create(dev_config=config.dev, block_number=5,
+                                      prev_headerhash=block_4.headerhash, prev_timestamp=block_4.timestamp,
+                                      transactions=[multi_sig_unvote], miner_address=alice_xmss.address,
+                                      seed_height=seed_block.block_number, seed_hash=seed_block.headerhash)
+            side_block.set_nonces(config.dev, 0, 0)
+
+            # Simulate a side-branch block persisted with a stale/attacker-chosen
+            # prev_tx_hash. prev_tx_hash is not part of the txhash or signature, so this
+            # does not change the block's headerhash and the block stays otherwise valid.
+            # transactions[0] is the coinbase; the multisig vote is transactions[1].
+            stale_prev_tx_hash = b'\xab' * 32
+            side_block._data.transactions[1].multi_sig_vote.prev_tx_hash = stale_prev_tx_hash
+            Block.put_block(self.state, side_block, None)
+            self.state.write_batch(self.state.batch)
+
+            # Sanity: storage holds the stale value before the side branch is applied.
+            stored_before = Block.get_block(self.state, side_block.headerhash)
+            self.assertEqual(stored_before.transactions[1].multi_sig_vote.prev_tx_hash, stale_prev_tx_hash)
+
+            # Apply the already-persisted side branch as canonical (the path fork
+            # recovery uses). self._last_block is block_4, the fork point.
+            fork_state = qrlstateinfo_pb2.ForkState(fork_point_headerhash=block_4.headerhash)
+            self.assertTrue(self.chain_manager.add_chain([side_block.headerhash], fork_state))
+
+            # The block persisted in the DB must now carry the normalized prev_tx_hash
+            # (vote1's txhash), not the stale value. Without the re-persist in add_chain(),
+            # the stored bytes would still be `stale_prev_tx_hash`.
+            stored_after = Block.get_block(self.state, side_block.headerhash)
+            self.assertEqual(stored_after.transactions[1].multi_sig_vote.prev_tx_hash,
+                             multi_sig_vote1.txhash)
+            self.assertNotEqual(stored_after.transactions[1].multi_sig_vote.prev_tx_hash,
+                                stale_prev_tx_hash)
+
+    @set_default_balance_size()
+    @set_hard_fork_block_number()
+    @patch('qrl.core.misc.ntp.getTime')
     def test_add_block3(self, time_mock):
         """
         Features Tested

--- a/tests/core/test_ChainManager.py
+++ b/tests/core/test_ChainManager.py
@@ -658,6 +658,44 @@ class TestChainManagerReal(TestCase):
     @set_default_balance_size()
     @set_hard_fork_block_number()
     @patch('qrl.core.misc.ntp.getTime')
+    def test_validate_all_rejects_transfer_to_nonexistent_multisig_address(self, time_mock):
+        """
+        Regression test: a transfer to a syntactically valid but nonexistent multi-sig
+        address must be rejected cleanly by validation, not crash state loading.
+
+        get_state_mainchain() loads the recipient's MultiSigAddressState (None when the
+        address does not exist) and previously dereferenced None.signatories, raising
+        AttributeError inside validate_all() before TransferTransaction._validate_extended()
+        could reject the missing recipient. The guard makes validate_all() return False.
+        """
+        with patch.object(DifficultyTracker, 'get', return_value=ask_difficulty_tracker('2', config.dev)):
+            self.chain_manager.load(self.genesis_block)
+            time_mock.return_value = 1615270948
+
+            alice_xmss = get_alice_xmss(4)
+
+            # A crafted multi-sig address (0x11 prefix, valid checksum) that was never
+            # created on-chain, so it has no MultiSigAddressState in the DB.
+            nonexistent_multisig_address = MultiSigAddressState.generate_multi_sig_address(b'nonexistent-multisig-creation-tx')
+            self.assertTrue(MultiSigAddressState.address_is_valid(nonexistent_multisig_address))
+            self.assertFalse(OptimizedAddressState.address_is_valid(nonexistent_multisig_address))
+
+            transfer = TransferTransaction.create(addrs_to=[nonexistent_multisig_address],
+                                                  amounts=[1],
+                                                  message_data=None,
+                                                  fee=0,
+                                                  xmss_pk=alice_xmss.pk)
+            transfer.sign(alice_xmss)
+            transfer.pbdata.nonce = 1
+
+            # Must reject cleanly (return False) rather than raising AttributeError
+            # from None.signatories inside get_state_mainchain().
+            result = self.chain_manager.validate_all(transfer, check_nonce=False)
+            self.assertFalse(result)
+
+    @set_default_balance_size()
+    @set_hard_fork_block_number()
+    @patch('qrl.core.misc.ntp.getTime')
     def test_add_block3(self, time_mock):
         """
         Features Tested

--- a/tests/core/txs/test_CoinBase.py
+++ b/tests/core/txs/test_CoinBase.py
@@ -232,8 +232,7 @@ class TestCoinBase(TestCase):
         self.assertTrue(tx._validate_custom())
 
     def test_validate_custom_rejects_tampered_addr_to(self, m_logger):
-        """Changing the body after the hash is stored is rejected: transaction_hash
-        no longer equals get_data_hash()."""
+        """Reject tampered body when transaction_hash no longer equals get_data_hash()."""
         tx = CoinBase.create(config.dev, self.amount, self.alice.address,
                              self.mock_blockheader.block_number)
         self.assertTrue(tx._validate_custom())
@@ -255,8 +254,7 @@ class TestCoinBase(TestCase):
         self.assertFalse(tx._validate_custom())
 
     def test_validate_extended_rejects_tampered_addr_to(self, m_logger):
-        """The binding check also rejects through _validate_extended, the coinbase
-        validation entry point."""
+        """Reject tampered body through _validate_extended, the coinbase validation entry point."""
         bob = get_bob_xmss()
         tx = CoinBase.create(config.dev, self.amount, self.alice.address,
                              self.mock_blockheader.block_number)

--- a/tests/core/txs/test_CoinBase.py
+++ b/tests/core/txs/test_CoinBase.py
@@ -15,7 +15,7 @@ from qrl.core.BlockHeader import BlockHeader
 from qrl.core.txs.CoinBase import CoinBase
 from qrl.crypto.misc import sha256
 from tests.core.txs.testdata import test_json_CoinBase
-from tests.misc.helper import get_alice_xmss, set_qrl_dir
+from tests.misc.helper import get_alice_xmss, get_bob_xmss, set_qrl_dir
 
 logger.initialize_default()
 
@@ -222,3 +222,64 @@ class TestCoinBase(TestCase):
 
         self.assertGreater(tx.size, tx.max_size_limit)
         self.assertFalse(tx._validate_custom())
+
+    # Regression: coinbase transaction_hash must be bound to the coinbase body.
+    def test_validate_custom_accepts_honest_coinbase(self, m_logger):
+        """A coinbase whose transaction_hash equals get_data_hash() is accepted."""
+        tx = CoinBase.create(config.dev, self.amount, self.alice.address,
+                             self.mock_blockheader.block_number)
+        self.assertEqual(tx.txhash, tx.get_data_hash())
+        self.assertTrue(tx._validate_custom())
+
+    def test_validate_custom_rejects_tampered_addr_to(self, m_logger):
+        """Changing the body after the hash is stored is rejected: transaction_hash
+        no longer equals get_data_hash()."""
+        tx = CoinBase.create(config.dev, self.amount, self.alice.address,
+                             self.mock_blockheader.block_number)
+        self.assertTrue(tx._validate_custom())
+
+        stale_hash = tx.txhash
+        tx._data.coinbase.addr_to = get_bob_xmss().address   # change the body, leave transaction_hash as-is
+        self.assertEqual(stale_hash, tx.txhash)
+        self.assertNotEqual(tx.txhash, tx.get_data_hash())
+
+        self.assertFalse(tx._validate_custom())
+
+    def test_validate_custom_rejects_chosen_transaction_hash(self, m_logger):
+        """A transaction_hash that does not equal get_data_hash() is rejected."""
+        tx = CoinBase.create(config.dev, self.amount, self.alice.address,
+                             self.mock_blockheader.block_number)
+        tx._data.transaction_hash = b'not-the-body-hash'
+        self.assertNotEqual(tx.txhash, tx.get_data_hash())
+
+        self.assertFalse(tx._validate_custom())
+
+    def test_validate_extended_rejects_tampered_addr_to(self, m_logger):
+        """The binding check also rejects through _validate_extended, the coinbase
+        validation entry point."""
+        bob = get_bob_xmss()
+        tx = CoinBase.create(config.dev, self.amount, self.alice.address,
+                             self.mock_blockheader.block_number)
+        tx._data.master_addr = config.dev.coinbase_address
+        tx._data.coinbase.addr_to = bob.address              # change the body, leave transaction_hash as-is
+
+        addresses_state = {
+            config.dev.coinbase_address: OptimizedAddressState.get_default(config.dev.coinbase_address),
+            bob.address: OptimizedAddressState.get_default(bob.address),
+        }
+        addresses_state[config.dev.coinbase_address].pbdata.balance = 1000000
+
+        state_container = StateContainer(addresses_state=addresses_state,
+                                         tokens=Indexer(b'token', None),
+                                         slaves=Indexer(b'slave', None),
+                                         lattice_pk=Indexer(b'lattice_pk', None),
+                                         multi_sig_spend_txs=dict(),
+                                         votes_stats=dict(),
+                                         block_number=self.mock_blockheader.block_number,
+                                         total_coin_supply=100,
+                                         current_dev_config=config.dev,
+                                         write_access=True,
+                                         my_db=self.state._db,
+                                         batch=None)
+
+        self.assertFalse(tx._validate_extended(state_container))

--- a/tests/core/txs/test_TokenTransaction.py
+++ b/tests/core/txs/test_TokenTransaction.py
@@ -72,6 +72,37 @@ class TestTokenTransaction(TestCase):
                                     fee=-1,
                                     xmss_pk=self.alice.pk)
 
+    def test_create_duplicate_initial_balance_overflow_fails(self, m_logger):
+        # Two initial_balances entries for the SAME address, each individually a
+        # valid uint64, but whose aggregate exceeds uint64. apply() merges
+        # duplicate recipients, so without an aggregate bound this would pass
+        # validation and then overflow the protobuf uint64 TokenBalance.balance
+        # during state application. Validation must reject it up front.
+        max_u64 = 2 ** 64 - 1
+        initial_balances = [qrl_pb2.AddressAmount(address=self.alice.address, amount=max_u64),
+                            qrl_pb2.AddressAmount(address=self.alice.address, amount=1)]
+        with self.assertRaises(ValueError):
+            self.make_tx(decimals=0, initial_balances=initial_balances)
+
+    def test_create_initial_balance_sum_overflow_distinct_addresses_fails(self, m_logger):
+        # The bound is on the total supply, not just on duplicate addresses:
+        # supply must fit in uint64 so that no balance can overflow across the
+        # token's lifetime (creation and conserved transfers).
+        half = 2 ** 63
+        initial_balances = [qrl_pb2.AddressAmount(address=self.alice.address, amount=half),
+                            qrl_pb2.AddressAmount(address=self.bob.address, amount=half)]
+        with self.assertRaises(ValueError):
+            self.make_tx(decimals=0, initial_balances=initial_balances)
+
+    def test_create_initial_balance_sum_equals_max_uint64_allowed(self, m_logger):
+        # Boundary: a total supply of exactly uint64 max must still be accepted
+        # (guards against a regression to a `>=` off-by-one).
+        max_u64 = 2 ** 64 - 1
+        initial_balances = [qrl_pb2.AddressAmount(address=self.alice.address, amount=max_u64 - 1),
+                            qrl_pb2.AddressAmount(address=self.alice.address, amount=1)]
+        tx = self.make_tx(decimals=0, initial_balances=initial_balances)
+        self.assertIsNotNone(tx)
+
     def test_to_json(self, m_logger):
         initial_balances = list()
         initial_balances.append(qrl_pb2.AddressAmount(address=self.alice.address,

--- a/tests/test_grpcProxy.py
+++ b/tests/test_grpcProxy.py
@@ -1,8 +1,7 @@
 # coding=utf-8
 # Distributed under the MIT software license, see the accompanying
 # file LICENSE or http://www.opensource.org/licenses/mit-license.php.
-"""
-Safety guard for the grpcProxy migration from GetAddressState to GetOTS/IsSlave.
+"""Safety guard for the grpcProxy migration from GetAddressState to GetOTS/IsSlave.
 
 grpcProxy.set_unused_ots_key now asks the node for the next unused OTS index via
 GetOTS -> qrlnode.get_ots -> ChainManager.get_unused_ots_index2, instead of

--- a/tests/test_grpcProxy.py
+++ b/tests/test_grpcProxy.py
@@ -1,0 +1,157 @@
+# coding=utf-8
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+"""
+Safety guard for the grpcProxy migration from GetAddressState to GetOTS/IsSlave.
+
+grpcProxy.set_unused_ots_key now asks the node for the next unused OTS index via
+GetOTS -> qrlnode.get_ots -> ChainManager.get_unused_ots_index2, instead of
+pulling the whole (unpaginated) AddressState and scanning the bitfield with
+AddressState.ots_key_reuse client-side.
+
+Choosing a *used* OTS index would mean XMSS one-time-signature key reuse, so the
+core test here pins the safety property: for the same on-disk bitfield state, the
+new paginated path must return exactly the same index the old client-side scan
+would have.
+
+Scope: equivalence is asserted for real XMSS heights (even, <= 12 -> <= 4096
+keys). Under the default config ots_tracking_per_page == max_ots_tracking_index
+== 8192, so those keys occupy a single tracking page and stay below the
+ots_counter fallback -- the regime every payment slave actually uses. Heights
+>= 14 cross max_ots_tracking_index, where the legacy AddressState path
+deliberately falls back to ots_counter and the two representations differ by
+design; that is out of scope (and impractical for payment slaves).
+"""
+from unittest import TestCase
+
+from mock import Mock, patch
+
+from qrl.core.ChainManager import ChainManager
+from qrl.core.GenesisBlock import GenesisBlock
+from qrl.core.OptimizedAddressState import OptimizedAddressState
+from qrl.core.PaginatedBitfield import PaginatedBitfield
+from qrl.core.State import State
+from qrl.generated import qrl_pb2
+from qrl import grpcProxy
+from tests.misc.helper import get_alice_xmss, setup_qrl_dir_without_ctx, cleanup_qrl_dir
+
+
+class TestGetUnusedOTSIndexEquivalence(TestCase):
+    """The new GetOTS-based index selection must match the old client-side scan."""
+
+    def setUp(self):
+        self.dst_dir, self.prev_val = setup_qrl_dir_without_ctx('no_data')
+        self.state = State()
+        try:
+            del GenesisBlock.instance  # Removing Singleton instance
+        except Exception:  # noqa
+            pass
+        GenesisBlock()
+        self.chain_manager = ChainManager(self.state)
+
+    def tearDown(self):
+        cleanup_qrl_dir(self.dst_dir, self.prev_val)
+
+    def _mark_used(self, address, used_indices):
+        addresses_state = {address: OptimizedAddressState.get_default(address)}
+        paginated_bitfield = PaginatedBitfield(True, self.state._db)
+        for i in used_indices:
+            paginated_bitfield.set_ots_key(addresses_state, address, i)
+        paginated_bitfield.put_addresses_bitfield(None)
+        OptimizedAddressState.put_optimized_addresses_state(self.state, addresses_state)
+
+    def _legacy_first_unused(self, addr_state, height, start):
+        # Exactly what the removed grpcProxy.set_unused_ots_key scan did.
+        for i in range(start, 2 ** height):
+            if not addr_state.ots_key_reuse(i):
+                return i
+        return None
+
+    def _assert_equivalent(self, address, height, starts):
+        # Reconstruct the legacy AddressState once (this is what GetAddressState
+        # returned to the old proxy); the state does not change between starts.
+        addr_state = self.chain_manager.get_address_state(address)
+        for start in starts:
+            expected = self._legacy_first_unused(addr_state, height, start)
+            found = self.chain_manager.get_unused_ots_index2(address, start)
+            self.assertEqual(expected, found,
+                             "index mismatch at start={} (height={})".format(start, height))
+
+    def test_no_keys_used(self):
+        xmss = get_alice_xmss(6)  # 64 keys
+        self._assert_equivalent(xmss.address, xmss.height, range(0, 2 ** xmss.height + 1))
+
+    def test_scattered_keys_used(self):
+        xmss = get_alice_xmss(6)
+        self._mark_used(xmss.address, [0, 1, 2, 5, 8, 9, 16, 31, 32, 33, 62, 63])
+        self._assert_equivalent(xmss.address, xmss.height, range(0, 2 ** xmss.height + 1))
+
+    def test_all_keys_used(self):
+        xmss = get_alice_xmss(6)
+        self._mark_used(xmss.address, range(0, 2 ** xmss.height))
+        self._assert_equivalent(xmss.address, xmss.height, range(0, 2 ** xmss.height + 1))
+        # No unused index anywhere -> both paths return None.
+        self.assertIsNone(self.chain_manager.get_unused_ots_index2(xmss.address, 0))
+
+    def test_larger_height_sampled(self):
+        xmss = get_alice_xmss(10)  # 1024 keys, still a single tracking page
+        used = [0, 1, 7, 8, 63, 64, 255, 256, 511, 512, 1022, 1023]
+        self._mark_used(xmss.address, used)
+        starts = [0, 1, 2, 7, 8, 9, 63, 64, 255, 256, 511, 512, 1021, 1022, 1023, 1024]
+        self._assert_equivalent(xmss.address, xmss.height, starts)
+
+
+class TestGrpcProxyPaymentHelpers(TestCase):
+    """Direct coverage of the changed grpcProxy helpers using a mocked stub."""
+
+    def test_set_unused_ots_key_sets_index_from_getots(self):
+        stub = Mock()
+        stub.GetOTS.return_value = Mock(unused_ots_index_found=True, next_unused_ots_index=7)
+        xmss = get_alice_xmss(6)
+
+        result = grpcProxy.set_unused_ots_key(stub, xmss, start=3)
+
+        self.assertTrue(result)
+        self.assertEqual(7, xmss.ots_index)
+        request = stub.GetOTS.call_args[1]['request']
+        self.assertEqual(xmss.address, request.address)
+        self.assertEqual(3, request.unused_ots_index_from)
+        self.assertEqual(0, request.page_count)  # no bitfield pages requested
+
+    def test_set_unused_ots_key_returns_false_when_none_found(self):
+        stub = Mock()
+        stub.GetOTS.return_value = Mock(unused_ots_index_found=False, next_unused_ots_index=0)
+        xmss = get_alice_xmss(6)
+        xmss.set_ots_index(5)
+
+        result = grpcProxy.set_unused_ots_key(stub, xmss, start=3)
+
+        self.assertFalse(result)
+        self.assertEqual(5, xmss.ots_index)  # unchanged
+
+    def test_valid_payment_permission_true_for_registered_slave(self):
+        stub = Mock()
+        stub.IsSlave.return_value = Mock(result=True)
+        xmss = get_alice_xmss(6)
+
+        result = grpcProxy.valid_payment_permission(stub, b'master_address', xmss, '{}')
+
+        self.assertTrue(result)
+        stub.PushTransaction.assert_not_called()
+        request = stub.IsSlave.call_args[1]['request']
+        self.assertEqual(b'master_address', request.master_address)
+        self.assertEqual(xmss.pk, request.slave_pk)
+
+    def test_valid_payment_permission_pushes_registration_when_not_slave(self):
+        stub = Mock()
+        stub.IsSlave.return_value = Mock(result=False)
+        xmss = get_alice_xmss(6)
+
+        fake_tx = Mock()
+        fake_tx.pbdata = qrl_pb2.Transaction()  # real message so PushTransactionReq accepts it
+        with patch('qrl.grpcProxy.Transaction.from_json', return_value=fake_tx) as from_json:
+            result = grpcProxy.valid_payment_permission(stub, b'master_address', xmss, '{"slave": "txn"}')
+
+        self.assertIsNone(result)
+        from_json.assert_called_once_with('{"slave": "txn"}')
+        stub.PushTransaction.assert_called_once()

--- a/tests/test_grpcProxy.py
+++ b/tests/test_grpcProxy.py
@@ -22,6 +22,7 @@ ots_counter fallback -- the regime every payment slave actually uses. Heights
 deliberately falls back to ots_counter and the two representations differ by
 design; that is out of scope (and impractical for payment slaves).
 """
+from contextlib import suppress
 from unittest import TestCase
 
 from mock import Mock, patch
@@ -42,10 +43,8 @@ class TestGetUnusedOTSIndexEquivalence(TestCase):
     def setUp(self):
         self.dst_dir, self.prev_val = setup_qrl_dir_without_ctx('no_data')
         self.state = State()
-        try:
-            del GenesisBlock.instance  # Removing Singleton instance
-        except Exception:  # noqa
-            pass
+        with suppress(AttributeError):
+            del GenesisBlock.instance  # reset the singleton for this test's qrl_dir
         GenesisBlock()
         self.chain_manager = ChainManager(self.state)
 
@@ -60,7 +59,8 @@ class TestGetUnusedOTSIndexEquivalence(TestCase):
         paginated_bitfield.put_addresses_bitfield(None)
         OptimizedAddressState.put_optimized_addresses_state(self.state, addresses_state)
 
-    def _legacy_first_unused(self, addr_state, height, start):
+    @staticmethod
+    def _legacy_first_unused(addr_state, height, start):
         # Exactly what the removed grpcProxy.set_unused_ots_key scan did.
         for i in range(start, 2 ** height):
             if not addr_state.ots_key_reuse(i):


### PR DESCRIPTION
**Test updates**

* Added tests to verify that a coinbase transaction is only accepted if its `transaction_hash` matches the hash of its body data, ensuring integrity.
* Added tests to ensure that tampering with the coinbase body (e.g., changing `addr_to`) after the hash is set causes validation to fail, both in custom and extended validation paths.
* Added a test to ensure that manually setting an incorrect `transaction_hash` is rejected by validation.

**Test infrastructure update:**

* Imported `get_bob_xmss` from `tests.misc.helper` to support the new tampering tests.