### PR TITLE
Regression test and docstring nits

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -1,0 +1,11 @@
+# Prospector profile, used by Codacy's Prospector_pydocstyle analysis.
+#
+# pydocstyle ships D212 and D213 as mutually exclusive alternatives:
+#   D212 - multi-line docstring summary should start at the first line
+#   D213 - multi-line docstring summary should start at the second line
+# Codacy's default profile enables both, so every multi-line docstring reports
+# one of them whichever layout it uses. We follow D212, so D213 is disabled.
+pydocstyle:
+  run: true
+  disable:
+    - D213

--- a/src/qrl/core/Block.py
+++ b/src/qrl/core/Block.py
@@ -1,9 +1,10 @@
 # coding=utf-8
 # Distributed under the MIT software license, see the accompanying
 # file LICENSE or http://www.opensource.org/licenses/mit-license.php.
-"""
-Block: the on-chain block structure — assembly (create), consensus validation
-(validate), and helpers for persisting and reading blocks from the state DB.
+"""Block: the on-chain block structure.
+
+Assembly (create), consensus validation (validate), and helpers for persisting
+and reading blocks from the state DB.
 """
 from collections import OrderedDict
 from statistics import median
@@ -127,12 +128,12 @@ class Block(object):
                miner_address: bytes,
                seed_height: Optional[int],
                seed_hash: Optional[bytes]):
-        """
-        Assemble a new block: prepend the coinbase (block reward + summed
-        transaction fees) to the given transactions, build the transaction merkle
-        root, and create the matching header with mining nonces zeroed.
-        """
+        """Assemble a new block.
 
+        Prepend the coinbase (block reward + summed transaction fees) to the given
+        transactions, build the transaction merkle root, and create the matching
+        header with mining nonces zeroed.
+        """
         block = Block()
 
         # Process transactions

--- a/src/qrl/core/ChainManager.py
+++ b/src/qrl/core/ChainManager.py
@@ -1,10 +1,10 @@
 # coding=utf-8
 # Distributed under the MIT software license, see the accompanying
 # file LICENSE or http://www.opensource.org/licenses/mit-license.php.
-"""
-ChainManager: owns the chain's state — adding and validating blocks, fork
-detection and recovery, and applying/reverting transaction state changes against
-the state DB.
+"""ChainManager: owns the chain's state.
+
+Adding and validating blocks, fork detection and recovery, and applying/reverting
+transaction state changes against the state DB.
 """
 import sys
 import threading

--- a/src/qrl/grpcProxy.py
+++ b/src/qrl/grpcProxy.py
@@ -56,9 +56,10 @@ def valid_payment_permission(public_stub, master_address, payment_xmss, json_sla
 
 
 def get_unused_payment_xmss(public_stub):
-    """
-    Return a payment slave XMSS with an unused OTS key, rotating through the
-    configured slave seeds and registering the slave on the master if needed.
+    """Return a payment slave XMSS with an unused OTS key.
+
+    Rotates through the configured slave seeds and registers the slave on the
+    master if needed.
     """
     global payment_slaves
     global payment_xmss

--- a/tests/core/txs/test_CoinBase.py
+++ b/tests/core/txs/test_CoinBase.py
@@ -232,8 +232,7 @@ class TestCoinBase(TestCase):
         self.assertTrue(tx._validate_custom())
 
     def test_validate_custom_rejects_tampered_addr_to(self, m_logger):
-        """Changing the body after the hash is stored is rejected: transaction_hash
-        no longer equals get_data_hash()."""
+        """Reject tampered body when transaction_hash no longer equals get_data_hash()."""
         tx = CoinBase.create(config.dev, self.amount, self.alice.address,
                              self.mock_blockheader.block_number)
         self.assertTrue(tx._validate_custom())
@@ -255,8 +254,7 @@ class TestCoinBase(TestCase):
         self.assertFalse(tx._validate_custom())
 
     def test_validate_extended_rejects_tampered_addr_to(self, m_logger):
-        """The binding check also rejects through _validate_extended, the coinbase
-        validation entry point."""
+        """Reject tampered body through _validate_extended, the coinbase validation entry point."""
         bob = get_bob_xmss()
         tx = CoinBase.create(config.dev, self.amount, self.alice.address,
                              self.mock_blockheader.block_number)

--- a/tests/core/txs/test_CoinBase.py
+++ b/tests/core/txs/test_CoinBase.py
@@ -15,7 +15,7 @@ from qrl.core.BlockHeader import BlockHeader
 from qrl.core.txs.CoinBase import CoinBase
 from qrl.crypto.misc import sha256
 from tests.core.txs.testdata import test_json_CoinBase
-from tests.misc.helper import get_alice_xmss, set_qrl_dir
+from tests.misc.helper import get_alice_xmss, get_bob_xmss, set_qrl_dir
 
 logger.initialize_default()
 
@@ -222,3 +222,64 @@ class TestCoinBase(TestCase):
 
         self.assertGreater(tx.size, tx.max_size_limit)
         self.assertFalse(tx._validate_custom())
+
+    # Regression: coinbase transaction_hash must be bound to the coinbase body.
+    def test_validate_custom_accepts_honest_coinbase(self, m_logger):
+        """A coinbase whose transaction_hash equals get_data_hash() is accepted."""
+        tx = CoinBase.create(config.dev, self.amount, self.alice.address,
+                             self.mock_blockheader.block_number)
+        self.assertEqual(tx.txhash, tx.get_data_hash())
+        self.assertTrue(tx._validate_custom())
+
+    def test_validate_custom_rejects_tampered_addr_to(self, m_logger):
+        """Changing the body after the hash is stored is rejected: transaction_hash
+        no longer equals get_data_hash()."""
+        tx = CoinBase.create(config.dev, self.amount, self.alice.address,
+                             self.mock_blockheader.block_number)
+        self.assertTrue(tx._validate_custom())
+
+        stale_hash = tx.txhash
+        tx._data.coinbase.addr_to = get_bob_xmss().address   # change the body, leave transaction_hash as-is
+        self.assertEqual(stale_hash, tx.txhash)
+        self.assertNotEqual(tx.txhash, tx.get_data_hash())
+
+        self.assertFalse(tx._validate_custom())
+
+    def test_validate_custom_rejects_chosen_transaction_hash(self, m_logger):
+        """A transaction_hash that does not equal get_data_hash() is rejected."""
+        tx = CoinBase.create(config.dev, self.amount, self.alice.address,
+                             self.mock_blockheader.block_number)
+        tx._data.transaction_hash = b'not-the-body-hash'
+        self.assertNotEqual(tx.txhash, tx.get_data_hash())
+
+        self.assertFalse(tx._validate_custom())
+
+    def test_validate_extended_rejects_tampered_addr_to(self, m_logger):
+        """The binding check also rejects through _validate_extended, the coinbase
+        validation entry point."""
+        bob = get_bob_xmss()
+        tx = CoinBase.create(config.dev, self.amount, self.alice.address,
+                             self.mock_blockheader.block_number)
+        tx._data.master_addr = config.dev.coinbase_address
+        tx._data.coinbase.addr_to = bob.address              # change the body, leave transaction_hash as-is
+
+        addresses_state = {
+            config.dev.coinbase_address: OptimizedAddressState.get_default(config.dev.coinbase_address),
+            bob.address: OptimizedAddressState.get_default(bob.address),
+        }
+        addresses_state[config.dev.coinbase_address].pbdata.balance = 1000000
+
+        state_container = StateContainer(addresses_state=addresses_state,
+                                         tokens=Indexer(b'token', None),
+                                         slaves=Indexer(b'slave', None),
+                                         lattice_pk=Indexer(b'lattice_pk', None),
+                                         multi_sig_spend_txs=dict(),
+                                         votes_stats=dict(),
+                                         block_number=self.mock_blockheader.block_number,
+                                         total_coin_supply=100,
+                                         current_dev_config=config.dev,
+                                         write_access=True,
+                                         my_db=self.state._db,
+                                         batch=None)
+
+        self.assertFalse(tx._validate_extended(state_container))

--- a/tests/test_grpcProxy.py
+++ b/tests/test_grpcProxy.py
@@ -1,8 +1,7 @@
 # coding=utf-8
 # Distributed under the MIT software license, see the accompanying
 # file LICENSE or http://www.opensource.org/licenses/mit-license.php.
-"""
-Safety guard for the grpcProxy migration from GetAddressState to GetOTS/IsSlave.
+"""Safety guard for the grpcProxy migration from GetAddressState to GetOTS/IsSlave.
 
 grpcProxy.set_unused_ots_key now asks the node for the next unused OTS index via
 GetOTS -> qrlnode.get_ots -> ChainManager.get_unused_ots_index2, instead of


### PR DESCRIPTION
This pull request focuses on improving code documentation and adding regression tests for coinbase transaction validation. Key changes include standardizing docstring formatting to comply with style guidelines, clarifying docstrings for better readability, and introducing new tests to ensure the integrity of coinbase transaction validation.

**Documentation and Style Improvements:**

* Added a `.prospector.yaml` configuration to disable the conflicting D213 pydocstyle warning, ensuring consistency with the project's docstring style.
* Reformatted module-level and function docstrings in `Block.py`, `ChainManager.py`, and `grpcProxy.py` for clarity and compliance with the D212 style guideline. [[1]](diffhunk://#diff-ffb8e452ce27babb4665f4763ed5a1a923ef42a404fc70899cfcad036cdd24ccL4-R7) [[2]](diffhunk://#diff-123f46c74243276d66a00c2f2d2a6398505d53cb8f67c4192cdacdebddc240f9L4-R7) [[3]](diffhunk://#diff-e3f394af0c97f98e1bf0cc9222b360a03380989e0e37f89854cced19c639526cL59-R62) [[4]](diffhunk://#diff-84a8ff3dfa4528e9a638feebd2b1e084cc312a6434ba4bd21abc326b4a14a99dL4-R4)

**Testing and Validation:**

* Added regression tests in `test_CoinBase.py` to verify that the coinbase transaction hash is correctly bound to the transaction body and to reject tampered or invalid coinbase transactions. [[1]](diffhunk://#diff-cad03019d82423f3c6b569c126404f33bfb275921b91b7818c2dd8b165f291f1L18-R18) [[2]](diffhunk://#diff-cad03019d82423f3c6b569c126404f33bfb275921b91b7818c2dd8b165f291f1R225-R283)

These changes improve code maintainability, enforce consistent documentation standards, and strengthen the reliability of coinbase transaction validation.