### PR TITLE
Harden TransferToken apply after an in-memory revert

### DIFF
--- a/src/qrl/core/txs/TransferTokenTransaction.py
+++ b/src/qrl/core/txs/TransferTokenTransaction.py
@@ -173,18 +173,23 @@ class TransferTokenTransaction(Transaction):
             addr_to = self.addrs_to[index]
             amount = self.amounts[index]
             address_state = state_container.addresses_state[addr_to]
+            key = (addr_to, self.token_txhash)
 
             # If receiver doesn't have this token before, then initialize token balance data into state
             # before adding the new balance.
-            if (addr_to, self.token_txhash) not in state_container.tokens.data:
-                state_container.tokens.data[(addr_to,
-                                             self.token_txhash)] = TokenBalance(balance=0,
-                                                                                decimals=decimals,
-                                                                                tx_hash=self.txhash,
-                                                                                delete=False)
+            if key not in state_container.tokens.data:
+                state_container.tokens.data[key] = TokenBalance(balance=0,
+                                                                decimals=decimals,
+                                                                tx_hash=self.txhash,
+                                                                delete=False)
+                state_container.paginated_tokens_hash.insert(address_state, self.token_txhash)
+            elif state_container.tokens.data[key].delete:
+                # Keep apply() safe for callers that reuse a StateContainer after
+                # reverting a transfer which originally created this token entry.
+                state_container.tokens.data[key].delete = False
                 state_container.paginated_tokens_hash.insert(address_state, self.token_txhash)
 
-            state_container.tokens.data[(addr_to, self.token_txhash)].balance += amount
+            state_container.tokens.data[key].balance += amount
 
             if self.addr_from != addr_to:
                 state_container.paginated_tx_hash.insert(address_state, self.txhash)

--- a/tests/core/txs/test_TransferTokenTransactionStateChanges.py
+++ b/tests/core/txs/test_TransferTokenTransactionStateChanges.py
@@ -182,6 +182,42 @@ class TestTransferTokenTransactionStateChanges(TestCase):
         self.assertEqual(tokens.data[(self.alice.address, tx.token_txhash)].balance, 1000)
         self.assertEqual(tokens.data[(self.bob.address, tx.token_txhash)].balance, 0)
 
+    def test_apply_reactivates_receiver_token_after_revert(self):
+        """
+        Re-applying a reverted transfer on the same StateContainer must restore
+        both the receiver token entry and its paginated index.
+        """
+        tx = TransferTokenTransaction.create(**self.params)
+        tx.sign(self.alice)
+        addresses_state = dict(self.addresses_state)
+        tokens = Indexer(b'token', None)
+        tokens.data[(self.alice.address, tx.token_txhash)] = TokenBalance(balance=1000)
+        state_container = StateContainer(addresses_state=addresses_state,
+                                         tokens=tokens,
+                                         slaves=Indexer(b'slave', None),
+                                         lattice_pk=Indexer(b'lattice_pk', None),
+                                         multi_sig_spend_txs=dict(),
+                                         votes_stats=dict(),
+                                         block_number=1,
+                                         total_coin_supply=1000,
+                                         current_dev_config=config.dev,
+                                         write_access=True,
+                                         my_db=self.state._db,
+                                         batch=None)
+
+        bob_token_key = (self.bob.address, tx.token_txhash)
+
+        self.assertTrue(tx.apply(self.state, state_container))
+        self.assertTrue(tx.revert(self.state, state_container))
+        self.assertTrue(tokens.data[bob_token_key].delete)
+        self.assertEqual(0, addresses_state[self.bob.address].tokens_count())
+
+        self.assertTrue(tx.apply(self.state, state_container))
+
+        self.assertEqual(100, tokens.data[bob_token_key].balance)
+        self.assertFalse(tokens.data[bob_token_key].delete)
+        self.assertEqual(1, addresses_state[self.bob.address].tokens_count())
+
     def test_revert_transfer_token_txn_multi_send(self):
         """
         Alice has 1100 tokens and 100 QRL, Bob and Slave have none. Alice sends some tokens to Bob and Slave.


### PR DESCRIPTION
## Summary

* reactivate an existing receiver token entry when it is marked for deletion
* restore the receiver's paginated token reference when the entry is reactivated
* add regression coverage for an `apply -> revert -> apply` sequence on a reused `StateContainer`

## Motivation

The current `ChainManager` creates fresh state containers while rolling back and applying blocks, so the normal fork-recovery path does not depend on this change. However, `TransferTokenTransaction.apply()` currently assumes that any token entry already present in the supplied container is active.

If a direct caller or future refactor reuses a container after reverting a transfer that originally created the receiver's token entry, `apply()` increments the balance while leaving the entry marked `delete=True` and absent from the paginated token index.

This change makes `apply()` self-consistent for that defensive case without changing the normal block-processing flow.

## Test plan

The new regression test fails on the base commit because the receiver entry remains marked for deletion after re-application. With this change applied:

```text
tests/core/txs/test_TransferTokenTransaction.py ..........
tests/core/txs/test_TransferTokenTransactionStateChanges.py ........

18 passed
```

`git diff --check` and Python syntax compilation also pass.
